### PR TITLE
Fixed slight bug in fuel/application/config/config.php

### DIFF
--- a/fuel/application/config/config.php
+++ b/fuel/application/config/config.php
@@ -12,7 +12,7 @@
 |
 */
 
-if ($_SERVER['SERVER_PORT'] != '80')
+if ($_SERVER['SERVER_PORT'] !== '80')
 {
 	$config['base_url'] = "http://".$_SERVER['SERVER_NAME'].':'.$_SERVER['SERVER_PORT'].str_replace(basename($_SERVER['SCRIPT_NAME']),"",$_SERVER['SCRIPT_NAME']);
 }


### PR DESCRIPTION
Fixed a slight bug on line 15 of fuel/application/config/config.php

I'm on a windows box with Apache 2.2. and php 5.2 installed.

Apache is not installed on the default port 80 but on a different port. But after I install FUEL-CMS the admin login screen was always opened with the default port 80. Line 15, i discovered, was were the problem lay. 

I suspect that it might be windows only issue tho.
