### PR TITLE
Multiple uploaded files data available to modules and models

### DIFF
--- a/fuel/modules/fuel/controllers/module.php
+++ b/fuel/modules/fuel/controllers/module.php
@@ -4,7 +4,10 @@ require_once(FUEL_PATH.'/libraries/Fuel_base_controller.php');
 class Module extends Fuel_base_controller {
 	
 	public $module = '';
-	
+
+	// array of data about all (if any) uploaded files
+	public $upload_data = array();
+
 	function __construct()
 	{
 		parent::__construct();
@@ -1300,11 +1303,18 @@ class Module extends Fuel_base_controller {
 								add_error($this->upload->display_errors('', ''));
 								$this->session->set_flashdata('error', $this->upload->display_errors('', ''));
 							}
+							else
+							{
+								// saves data about successfully uploaded file
+								$this->upload_data[] = $this->upload->data();
+							}
 						}
 					}
 				}
 			}
 		}
+		// transfers data about successfully uploaded file to the model
+		$this->model->upload_data = $this->upload_data;
 		return !$errors;
 	}
 }

--- a/fuel/modules/fuel/models/base_module_model.php
+++ b/fuel/modules/fuel/models/base_module_model.php
@@ -33,6 +33,7 @@ class Base_module_model extends MY_Model {
 	public $filter_value = NULL; // the values of the filters
 	public $filter_join = 'or'; // how to combine the filters in the query (and or or)
 	public $parsed_fields = array(); // fields to automatically parse
+	public $upload_data = array(); // data about all uploaded files
 	protected $_tables = array(); // fuel tables
 	
 	/**


### PR DESCRIPTION
Saves data about all uploaded files to array which is then available to the module (and model). 

It's very convinient when processing uploaded files in on_after_post() hook while having more than one file uploaded (multiple). For example resizing multiple images. 

Current way of getting data (using $CI->upload->data()) gives you last uploaded file's data only.
