### PR TITLE
Ability to check error when deleting items and use a custom error message (or default one).

### DIFF
--- a/fuel/modules/fuel/controllers/module.php
+++ b/fuel/modules/fuel/controllers/module.php
@@ -875,11 +875,33 @@ class Module extends Fuel_base_controller {
 		if (!empty($_POST['id']))
 		{
 			$posted = explode('|', $this->input->post('id'));
-			foreach($posted as $id)
+			
+			// Flags
+			$any_success = $any_failure = FALSE;
+			foreach ($posted as $id)
 			{
-				$this->model->delete(array($this->model->key_field() => $id));
+				if ($this->model->delete(array($this->model->key_field() => $id)))
+					$any_success = TRUE;
+				else
+					$any_failure = TRUE;
 			}
-			$this->session->set_flashdata('success', lang('data_deleted'));
+			// set a success delete message
+			if ($any_success)
+				$this->session->set_flashdata('success', lang('data_deleted'));
+			
+			// set an error delete message
+			if ($any_failure)
+			{
+				// first try to get an error added in model by $this->add_error('...')
+				$msg = $this->model->get_validation()->get_last_error();
+				
+				// if there is none like that, lets use default message
+				if (is_null($msg))
+					$msg = lang('data_not_deleted');
+
+				$this->session->set_flashdata('error', $msg);
+			}
+
 			$this->_clear_cache();
 			$this->logs_model->logit('Multiple module '.$this->module.' data deleted');
 			redirect(fuel_uri($this->module_uri));

--- a/fuel/modules/fuel/language/english/fuel_lang.php
+++ b/fuel/modules/fuel/language/english/fuel_lang.php
@@ -149,6 +149,7 @@ $lang['cannot_determine_module'] = "Cannot determine module.";
 $lang['incorrect_route_to_module'] = "Incorrect route to access this module.";
 $lang['data_saved'] = 'Data has been saved.';
 $lang['data_deleted'] = 'Data has been deleted.';
+$lang['data_not_deleted'] = 'Data couldn\'t have been deleted.';
 $lang['no_data'] = 'No data to display.';
 $lang['no_preview_path'] = 'There is no preview path assigned to this module.';
 $lang['delete_item_message'] = 'You are about to delete the item:';


### PR DESCRIPTION
Fuel Module controller now checks for failure while deleting item(s) and if it fails, allows to use either custom error message or default one defined in language files.

Example from some custom module's model:

```
function delete($where)
{
    $CI = & get_instance();
    $CI->load->module_model(SOME_FOLDER, 'other_model');
    $count = $CI->other_model->record_count(array('category_id' => $where['id']));
    if ($count > 0)
    {
        if ($count > 1)
            $this->add_error('There are ' . $count . ' obejcts in this category. You need to change it before deleting the category.');
        else
            $this->add_error('There is an object in this category. You need to change it before deleting the category.');
        return FALSE;
    }
    return parent::delete($where);
}
```
