### PR TITLE
Fix for Profiler to show executed queries

### DIFF
--- a/fuel/application/core/MY_Model.php
+++ b/fuel/application/core/MY_Model.php
@@ -55,7 +55,7 @@ class MY_Model extends CI_Model {
 	public $linked_fields = array(); // fields that are are linked. Key is the field, value is a function name to transform it
 	public $foreign_keys = array(); // map foreign keys to table models
 	
-	public $db; // CI database object
+	protected $db; // CI database object
 	protected $table_name; // the table name to associate the model with
 	protected $key_field = 'id'; // usually the tables primary key(s)... can be an array if compound key
 	protected $normalized_save_data = NULL; // the saved data before it is cleaned

--- a/fuel/application/libraries/MY_Profiler.php
+++ b/fuel/application/libraries/MY_Profiler.php
@@ -58,9 +58,10 @@ class MY_Profiler extends CI_Profiler {
 				// check each module for databases
 				else if (is_subclass_of(get_class($CI_object), 'CI_Model') )
 				{
-					if (is_object($CI_object->db) && is_subclass_of(get_class($CI_object->db), 'CI_DB'))
+					$module_db = $CI_object->db();
+					if (is_object($module_db) && is_subclass_of(get_class($module_db), 'CI_DB'))
 					{
-						$dbs[get_class($CI_object)] = $CI_model_object;
+						$dbs[get_class($CI_object)] = $module_db;
 					}
 				}
 			}


### PR DESCRIPTION
This fixes the 'No queries were run' message, while the modules actually run queries.
Every module gets his own block in the profiler with its name.
The Database object in MY_Model has to be public, otherwise we can't access it in the Profiler.
I think it's safe to assume only the $db variable in MY_Model needs to get checked for queries, so we only check that variable.

First pull request, so be kind, I need to learn how this shit works ;)
Comments are welcome of course.
