### PR TITLE
Boolean Form Checkboxes

### DIFF
--- a/fuel/application/core/MY_Model.php
+++ b/fuel/application/core/MY_Model.php
@@ -54,6 +54,7 @@ class MY_Model extends CI_Model {
 	public $unique_fields = array(); // fields that are not IDs but are unique
 	public $linked_fields = array(); // fields that are are linked. Key is the field, value is a function name to transform it
 	public $foreign_keys = array(); // map foreign keys to table models
+        public $boolean_fields = array(); // fields that are tinyint and should be treated as boolean
 	
 	protected $db; // CI database object
 	protected $table_name; // the table name to associate the model with
@@ -1734,6 +1735,13 @@ class MY_Model extends CI_Model {
 					$fields[$key]['options'] = array_combine($val['options'], $val['options']);
 				}
 			}
+                        
+                        // create boolean checkboxes
+                        if(in_array($val['name'], $this->boolean_fields) AND ($val['type'] === 'tinyint'))
+                        {
+                            $fields[$key]['type'] = 'checkbox';
+                            $fields[$key]['value'] = 1;                            
+                        }
 			
 			// get lang value if one exists... check first for model specific then look for a generic model lang key
 			// no longer needed because Form_builder does this

--- a/fuel/modules/fuel/assets/js/fuel/controller/BaseFuelController.js
+++ b/fuel/modules/fuel/assets/js/fuel/controller/BaseFuelController.js
@@ -281,7 +281,14 @@ fuel.controller.BaseFuelController = jqx.lib.BaseController.extend({
 
 		$('.activate_action').click(function(e){
 			$.removeChecksave();
-			if ($('#active').size() > 0){
+                        
+                        // Check if element is a checkbox
+                        if(undefined != $('#active:checkbox'))
+                        {
+                            $('#active:checkbox').attr('checked', true);
+                        }
+                        
+			else if ($('#active').size() > 0){
 				$('#active').val('yes');
 			} else {
 				$('#active_yes').attr('checked', true);
@@ -293,6 +300,13 @@ fuel.controller.BaseFuelController = jqx.lib.BaseController.extend({
 
 		$('.deactivate_action').click(function(e){
 			$.removeChecksave();
+                        
+                        // Check if element is a checkbox
+                        if(undefined != $('#active:checkbox'))
+                        {
+                            $('#active:checkbox').attr('checked', false);
+                        }
+                        
 			if ($('#active').size() > 0){
 				$('#active').val('no');
 			} else {

--- a/fuel/modules/fuel/helpers/fuel_helper.php
+++ b/fuel/modules/fuel/helpers/fuel_helper.php
@@ -748,3 +748,35 @@ function fuel_user_lang()
 	}
 	return $cookie_val['language'];
 }
+
+// --------------------------------------------------------------------
+
+/**
+ * Returns HTML for publish/active fields in the list view
+ *
+ * @access	public
+ * @return	string
+ */
+function fuel_unpublish_func($cols)
+{   
+        $CI = & get_instance();
+        $can_publish = $CI->fuel_auth->has_permission($CI->permission, "publish");
+        $is_publish = (isset($cols['published'])) ? TRUE : FALSE;
+        $no = lang("form_enum_option_no");
+        $yes = lang("form_enum_option_yes");            
+
+        if ((isset($cols['published']) AND $cols['published'] == "no") OR (isset($cols['active']) AND $cols['active'] == "no"))
+        {
+            $text_class = ($can_publish) ? "publish_text unpublished toggle_publish" : "unpublished";
+            $action_class = ($can_publish) ? "publish_action unpublished hidden" : "unpublished hidden";
+            $col_txt = ($is_publish) ? 'click to publish' : 'click to activate';
+            return '<span class="publish_hover"><span class="".$text_class."" id="row_published_".$cols["' . $CI->model->key_field() . '"]."">".$no."</span><span class="".$action_class."">".$col_txt."</span></span>';
+        }
+        else if ((isset($cols['published']) AND $cols['published'] == "yes") OR (isset($cols['active']) AND $cols['active'] == "yes"))
+        {
+            $text_class = ($can_publish) ? "publish_text published toggle_unpublish" : "published";
+            $action_class = ($can_publish) ? "publish_action published hidden" : "published hidden";
+            $col_txt = ($is_publish) ? 'click to unpublish' : 'click to deactivate';
+            return '<span class="publish_hover"><span class="'.$text_class.'" id="row_published_'.$cols[$CI->model->key_field()].'">'.$yes.'</span><span class="'.$action_class.'">'.$col_txt.'</span></span>';
+        }
+}


### PR DESCRIPTION
This allows MySQL TINYINT fields that are added to the model's boolean_fields property to be treated as a checkbox.
