### PR TITLE
fixed the hard coded page title on login page

### DIFF
--- a/fuel/modules/fuel/controllers/login.php
+++ b/fuel/modules/fuel/controllers/login.php
@@ -152,6 +152,7 @@ class Login extends CI_Controller {
 		$notifications = $this->load->view('_blocks/notifications', $vars, TRUE);
 		$vars['notifications'] = $notifications;
 		$vars['display_forgotten_pwd'] = $this->config->item('allow_forgotten_password', 'fuel');
+		$vars['page_title'] = lang('fuel_page_title');
 		$this->load->view('login', $vars);
 	}
 	
@@ -211,6 +212,7 @@ class Login extends CI_Controller {
 		// notifications template
 		$vars['error'] = $this->users_model->get_errors();
 		$vars['notifications'] = $this->load->view('_blocks/notifications', $vars, TRUE);
+		$vars['page_title'] = lang('fuel_page_title');
 		$this->load->view('pwd_reset', $vars);
 	}
 	
@@ -247,6 +249,7 @@ class Login extends CI_Controller {
 		
 		$vars['display_forgotten_pwd'] = FALSE;
 		$vars['instructions'] = lang('dev_pwd_instructions');
+		$vars['page_title'] = lang('fuel_page_title');
 		$this->load->view('login', $vars);
 		
 		

--- a/fuel/modules/fuel/views/login.php
+++ b/fuel/modules/fuel/views/login.php
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- 	<title>FUEL CMS</title>
+ 	<title><?=$page_title?></title>
 	<?=css('fuel', FUEL_FOLDER)?>
 	<script type="text/javascript">
 	<?=$this->load->module_view('fuel', '_blocks/fuel_header_jqx', array(), true)?>

--- a/fuel/modules/fuel/views/pwd_reset.php
+++ b/fuel/modules/fuel/views/pwd_reset.php
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
- 	<title>FUEL CMS</title>
+ 	<title><?=$page_title?></title>
 	<?=css('fuel', FUEL_FOLDER)?>
 	<script type="text/javascript">
 	<?=$this->load->module_view('fuel', '_blocks/fuel_header_jqx', array(), true)?>


### PR DESCRIPTION
using the language file fuel_page_title in stead of hardcoded.
