### PR TITLE
$lang['layout_field_main_copy'] Misspelling and Duplicate

### DIFF
--- a/fuel/modules/fuel/language/english/fuel_lang.php
+++ b/fuel/modules/fuel/language/english/fuel_lang.php
@@ -427,7 +427,7 @@ $lang['required_text'] = 'required fields';
 | Layouts
 |--------------------------------------------------------------------------
 */
-$lang['layout_fiel_main_copy'] = 'This is the main layout to be used for your site.';
+$lang['layout_field_main_copy'] = 'This is the main layout to be used for your site.';
 $lang['layout_field_page_title'] = 'Page title';
 $lang['layout_field_meta_description'] = 'Meta description';
 $lang['layout_field_meta_keywords'] = 'Meta keywords';
@@ -440,7 +440,6 @@ $lang['layout_field_301_redirect_copy'] = 'This layout will do a 301 redirect to
 $lang['layout_field_sitemap_xml_copy'] = 'This layout is used to generate a sitemap.';
 $lang['layout_field_none_copy'] = 'This layout is the equivalent of having no layout assigned.';
 
-$lang['layout_field_main_copy'] = 'This is the main layout to be used for your site.';
 $lang['layout_field_frequency'] = 'Frequency';
 $lang['layout_field_frequency_always'] = 'always';
 $lang['layout_field_frequency_hourly'] = 'hourly';


### PR DESCRIPTION
Fixed $lang['layout_field_main_copy'] misspelling in first instance and deleted second instance.
