### PR TITLE
Navigation

### DIFF
--- a/fuel/modules/fuel/views/_blocks/fuel_header.php
+++ b/fuel/modules/fuel/views/_blocks/fuel_header.php
@@ -43,8 +43,22 @@
 		<div id="fuel_left_panel_inner">
 			
 <?php 
+        // Get all modules
+        $modules = $this->fuel_modules->get_modules();
+        $mods = array();
+                
+        foreach($modules as $mod)
+        {
+            if(isset($mod['module_uri']))
+            {
+                // Index modules by their uri so we know which module belongs to a specific nav item
+                $mods[$mod['module_uri']] = isset($mod['permission']) ? $mod['permission'] : '';
+            }
+        }
+        
 	foreach($nav as $section => $nav_items)
 	{
+            
 		if (is_array($nav_items))
 		{
 			$header_written = FALSE;
@@ -53,6 +67,9 @@
 			{
 				$segments = explode('/', $key);
 				$url = $key;
+                                
+                                // Check for a specific module's permission                                
+                                $key = isset($mods[$key]) ? $mods[$key] : $key;
 				
 				// Convert wild-cards to RegEx
 				$nav_selected = str_replace(':any', '.+', str_replace(':num', '[0-9]+', $this->nav_selected));
@@ -105,3 +122,4 @@
 		</div>
 	</div>
 	<div id="main_panel">
+


### PR DESCRIPTION
Previously, navigation items are drawn only if the user has a permission that matches the navigation's URI. This fix builds the navigation based on the user's permission to a given module.
