### PR TITLE
Blog post default date added

### DIFF
--- a/fuel/modules/blog/models/blog_posts_model.php
+++ b/fuel/modules/blog/models/blog_posts_model.php
@@ -116,6 +116,14 @@ class Blog_posts_model extends Base_module_model {
 		$fields['date_added']['type'] = 'datetime'; // so it will auto add
 		$fields['last_modified']['type'] = 'hidden'; // so it will auto add
 		$fields['permalink']['order'] = 2; // for older versions where the schema order was different
+		
+		// Check if a date added value has been selected
+		if( ! isset($fields['date_added']['value']))
+		{
+			// Set a default date
+			$fields['date_added']['value'] = date('m/d/Y h:i:s a', time());
+		}
+		
 		return $fields;
 	}
 	


### PR DESCRIPTION
When adding a new blog post there is now a default date added with the current date and time.

This can still be overridden by the author.

I know if you leave it blank it defaults to the current date time in the database but I've found users prefer to see a date and time rather than leaving it blank.
