### PR TITLE
Remove extra $lang['form_label_overwrite']

### DIFF
--- a/fuel/modules/fuel/language/english/fuel_lang.php
+++ b/fuel/modules/fuel/language/english/fuel_lang.php
@@ -230,7 +230,6 @@ $lang['form_label_subfolder'] = 'Subfolder';
 $lang['form_label_overwrite'] = 'Overwrite';
 $lang['form_label_create_thumb'] = 'Create thumb';
 $lang['form_label_maintain_ratio'] = 'Maintain ratio';
-$lang['form_label_overwrite'] = 'Overwrite';
 $lang['form_label_width'] = 'Width';
 $lang['form_label_height'] = 'Height';
 $lang['form_label_master_dimension'] = 'Master dimension';


### PR DESCRIPTION
Variable $lang['form_label_overwrite'] already defined in line 230.
