### PR TITLE
Fix for 'filter support for range'

### DIFF
--- a/fuel/modules/fuel/models/base_module_model.php
+++ b/fuel/modules/fuel/models/base_module_model.php
@@ -325,9 +325,11 @@ class Base_module_model extends MY_Model {
 				}
 				
 				// from imknight https://github.com/daylightstudio/FUEL-CMS/pull/113#commits-pushed-57c156f
-				else if (preg_match('#_from#', $key) OR preg_match('#_to#', $key))
+				//else if (preg_match('#_from#', $key) OR preg_match('#_to#', $key))
+				else if (preg_match('#_from$#', $key) OR preg_match('#_fromequal$#', $key) OR preg_match('#_to$#', $key) OR preg_match('#_toequal$#', $key))
 				{
-					$key = strtr($key, array('_from' => ' >', '_fromequal' => ' >=', '_to' => ' <', '_toequal' => ' <='));
+					//$key = strtr($key, array('_from' => ' >', '_fromequal' => ' >=', '_to' => ' <', '_toequal' => ' <='));
+					$key = preg_replace(array('#_from$#', '#_fromequal$#', '#_to$#', '#_toequal$#'), array(' >', ' >=', ' <', ' <='), $key);
 					//$this->db->where(array($key => $val));
 					//$where_or[] = $key.'='.$this->db->escape($val);
 					array_push($$joiner_arr, $key.'='.$val);


### PR DESCRIPTION
Make sure that DB table name and/or field names which contain and do not end on "_from", "_fromequal", "_to" or "_toequal" are not changed by the function _list_items_query() when doing a search from a module in the fuel admin panel
