### PR TITLE
Changes to the Javascript Editor Initialization Order.  Allows editor to...

### DIFF
--- a/fuel/modules/fuel/views/_blocks/fuel_footer_jqx.php
+++ b/fuel/modules/fuel/views/_blocks/fuel_footer_jqx.php
@@ -1,0 +1,10 @@
+<?php
+// Place to modify javascript vars after the page has been partially rendered
+// For example change the editor which is used dynamically
+// IE...
+// echo 'jqx_config.editor="markitup";';
+// or 
+// echo 'jqx_config.editor="ckeditor";';
+// or
+// echo 'jqx_config.editor="'.echo editor_helper().';';
+?>

--- a/fuel/modules/fuel/views/_blocks/fuel_header.php
+++ b/fuel/modules/fuel/views/_blocks/fuel_header.php
@@ -16,13 +16,5 @@
 	<?=js($this->fuel->config('fuel_javascript'), 'fuel')?>
 	<?php foreach($js as $m => $j) : echo js(array($m => $j))."\n\t"; endforeach; ?>
 
-	<?php if (!empty($this->js_controller)) : ?> 
-	<script type="text/javascript">
-		<?php if ($this->js_controller != 'fuel.controller.BaseFuelController') : ?>
-		jqx.addPreload('fuel.controller.BaseFuelController');
-		<?php endif; ?>
-		jqx.init('<?=$this->js_controller?>', <?=json_encode($this->js_controller_params)?>, '<?=$this->js_controller_path?>');
-	</script>
-	<?php endif; ?>
 
 </head>

--- a/fuel/modules/fuel/views/_layouts/admin_main.php
+++ b/fuel/modules/fuel/views/_layouts/admin_main.php
@@ -95,6 +95,20 @@ $no_notification = (!$this->fuel->admin->has_panel('notification')) ? TRUE : FAL
 <?php $this->load->module_view(FUEL_FOLDER, '_blocks/fuel_bottom'); ?>
 <?php endif; ?>
 <?php */ ?>
+    
+    <script type="text/javascript">
+        <?=$this->load->module_view(FUEL_FOLDER, '_blocks/fuel_footer_jqx', array(), TRUE)?>
+    </script>
+    
+    <?php if (!empty($this->js_controller)) : ?> 
+    <script type="text/javascript">
+        <?php if ($this->js_controller != 'fuel.controller.BaseFuelController') : ?>
+        jqx.addPreload('fuel.controller.BaseFuelController');
+        <?php endif; ?>
+        jqx.init('<?=$this->js_controller?>', <?=json_encode($this->js_controller_params)?>, '<?=$this->js_controller_path?>');
+    </script>
+    <?php endif; ?>
+
 
 </body>
 </html>


### PR DESCRIPTION
This allows you to dynamicly change the editor that is used via php after the
page has partially rendered.

In my case I pick which editor based on a pre_hook call on the body field.

That hooks looks for stuff in the body that ckeditor would screw up, if so it swaps to markitup
