### PR TITLE
change $this->$module->config() to check settings (bugfix) in libraries/fuel_advanced_module

### DIFF
--- a/fuel/modules/fuel/libraries/Fuel_advanced_module.php
+++ b/fuel/modules/fuel/libraries/Fuel_advanced_module.php
@@ -390,7 +390,7 @@ class Fuel_advanced_module extends Fuel_base_library {
 		{
 			if ($look_in_settings)
 			{
-                if (is_array($this->settings())) //change from _settings to settings() because _settings isn't populated yet and settings() populates it
+                if (is_array($this->settings()))  //change from _settings to settings() because _settings isn't populated yet and settings() populates it
                     {
 					return array_merge($this->_config, $this->_settings);	
 				}


### PR DESCRIPTION
I found that with my new advanced module (invoices), settings were not being taken into account when calling $this->invoices->config(), instead just the config was used. I traced it to theis fix.  Changing _settings to settings() because _ settings is NULL until settings() grabs the settings.
Hope this is useful!
Thx Guy
