### PR TITLE
Related to fuel issue #246

### DIFF
--- a/fuel/modules/fuel/models/fuel_navigation_model.php
+++ b/fuel/modules/fuel/models/fuel_navigation_model.php
@@ -438,7 +438,7 @@ class Fuel_navigation_model extends Base_module_model {
 	 */	
 	public function is_new_location($location, $group_id, $parent_id, $lang)
 	{
-		if (empty($location)) return TRUE;
+		if (empty($location)) return FALSE;
 		if (empty($group_id)) return FALSE;
 		$data = $this->find_one_array(array('group_id' => $group_id, 'location' => $location, 'parent_id' => $parent_id, 'language' => $lang));
 		if (!empty($data)) return FALSE;
@@ -459,7 +459,7 @@ class Fuel_navigation_model extends Base_module_model {
 	 */
 	public function is_editable_location($location, $group_id, $parent_id, $id, $lang)
 	{
-		if (empty($location)) return TRUE;
+		if (empty($location)) return FALSE;
 		$data = $this->find_one_array(array('group_id' => $group_id, 'location' => $location, 'parent_id' => $parent_id, 'language' => $lang));
 		if (empty($data) || (!empty($data) && $data['id'] == $id)) return TRUE;
 		return FALSE;


### PR DESCRIPTION
This is what I think I have figured out, I should of never been able to create a empty location, which is what caused the strange create to update conversion I was seeing last week.  This patch makes it to where you can't edit or update a empty location.   

To duplicate the problem before applying this patch you can create a empty location, you can modify the empty location.  And when you try to create another empty location with the same parent the create gets converted to a update of the original id by the insert_ignore.  

After you apply this patch you can not longer create empty locations which solves the strange behavior.

Looking at the code it seems the intent is to never have a empty location.   So I have modified is_editable_location and is_new_location to return FALSE if the location is empty.
