### PR TITLE
Allow asset folder to be outside of WEB_ROOT

### DIFF
--- a/fuel/modules/fuel/libraries/Asset.php
+++ b/fuel/modules/fuel/libraries/Asset.php
@@ -539,7 +539,10 @@ class Asset {
 		$asset_type = (!empty($assets_folders[$path])) ? $assets_folders[$path] : $CI->config->item($path);
 		$path = WEB_ROOT.$assets_path.$asset_type.$file;
 		//$path = str_replace('/', DIRECTORY_SEPARATOR, $path); // for windows
-		return $path;
+		if(realpath($path))
+			return realpath($path);
+		else
+			return $path;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
If asset folder is outside of WEB_ROOT i.e. WEB_ROOT../assets/ then we need to return the realpath otherwise files are uploaded to the wrong directory