### PR TITLE
Added support for images with uppercase file extensions in the image selector

### DIFF
--- a/fuel/modules/fuel/assets/js/fuel/controller/AssetsController.js
+++ b/fuel/modules/fuel/assets/js/fuel/controller/AssetsController.js
@@ -23,7 +23,7 @@ fuel.controller.AssetsController = jqx.createController(fuel.controller.BaseFuel
 		var selectedAssetFolder = this.initObj.folder;
 		
 		$assetSelect.change(function(e){
-			var isImg = ($assetSelect.val() && $assetSelect.val().match(/\.jpg$|\.jpeg$|\.gif$|\.png$/));
+			var isImg = ($assetSelect.val() && $assetSelect.val().toLowerCase().match(/\.jpg$|\.jpeg$|\.gif$|\.png$/));
 			if (isImg){
 				$assetPreview.show().html('<img src="' + jqx.config.assetsPath + selectedAssetFolder + '/' + $assetSelect.val() + '" />');
 				$('.img_only').show();


### PR DESCRIPTION
When uploading images with an uppercase file extension, the image preview in the selector did not work.