### PR TITLE
Changed method of html insertion for images and links in the CKEditor

### DIFF
--- a/fuel/modules/fuel/assets/js/editors/ckeditor/plugins/fuelimage/plugin.js
+++ b/fuel/modules/fuel/assets/js/editors/ckeditor/plugins/fuelimage/plugin.js
@@ -58,7 +58,7 @@ CKEDITOR.plugins.add( 'fuelimage', {
 		   										return img;
 	    								}
 									);
-					editor.insertHtml(imgHtml);
+					editor.insertHtml(imgHtml,"unfiltered_html");
 				});
 				
 	        }

--- a/fuel/modules/fuel/assets/js/editors/ckeditor/plugins/fuellink/plugin.js
+++ b/fuel/modules/fuel/assets/js/editors/ckeditor/plugins/fuellink/plugin.js
@@ -47,7 +47,7 @@ CKEDITOR.plugins.add( 'fuellink', {
 					selected = selectedElem.getOuterHtml();
 				}
 				myMarkItUpSettings.displayLinkEditWindow(selected, {input: input, title: title, target: target, className: className, linkPdfs:linkPdfs}, function(replace){
-					editor.insertHtml(replace);
+					editor.insertHtml(replace, "unfiltered_html");
 				})
 	        }
     	});


### PR DESCRIPTION
Using the CKEditor, adding of links and images was not possible. This was fixed by using another html insertion method.

See http://docs.ckeditor.com/#!/api/CKEDITOR.editor insertHTML()
