### PR TITLE
on_before_validate called twice, validation_helper fails on non-integer numbers

### DIFF
--- a/fuel/modules/fuel/core/MY_Model.php
+++ b/fuel/modules/fuel/core/MY_Model.php
@@ -1452,7 +1452,6 @@ class MY_Model extends CI_Model {
 			// clean the data before saving. on_before_clean hook now runs in the clean() method
 			$values = $this->on_before_clean($values);
 			$values = $this->clean($values);
-			$values = $this->on_before_validate($values);
 
 			// now validate. on_before_validate hook now runs inside validate() method
 			$validated = ($validate) ? $this->validate($values) : TRUE;

--- a/fuel/modules/fuel/helpers/validator_helper.php
+++ b/fuel/modules/fuel/helpers/validator_helper.php
@@ -53,7 +53,7 @@ function required($var)
 		return !empty($var);
 	}
 	// automatically set integer values to TRUE
-	else if (is_int($var))
+	else if (is_numeric($var))
 	{
 		return TRUE;
 	}


### PR DESCRIPTION
on_before_validate is called twice, once before validate and once inside validate. 

Validation helper checks for integer instead of numeric causing non-integer numbers to fail required test
