### PR TITLE
Updated offline and development password mode.

### DIFF
--- a/fuel/modules/fuel/config/fuel.php
+++ b/fuel/modules/fuel/config/fuel.php
@@ -249,6 +249,12 @@ $config['password_max_length'] = NULL;
 // Sets specific patterns that the password must match (e.g. 'upper|lower|numbers|symbols')
 $config['password_pattern_match'] = NULL;
 
+// List of uri allowed to access when site switched to offline mode.
+// Eg.:
+// To allow "www.example.com/UAT"
+// $config['offline_allowed_uri'] = array('UAT');
+$config['offline_allowed_uri'] = array();
+
 // Restrict fuel to only certain ip addresses (can be string or an array of IP addresses)
 $config['restrict_to_remote_ip'] = array();
 

--- a/fuel/modules/fuel/config/fuel_hooks.php
+++ b/fuel/modules/fuel/config/fuel_hooks.php
@@ -20,7 +20,7 @@ $hook['pre_controller'][] = array(
 
 $hook['post_controller_constructor'][] = array(
 	'class' => 'Fuel_hooks',
-	'function' => 'dev_password',
+	'function' => 'offline',
 	'filename' => 'Fuel_hooks.php',
 	'filepath' => 'hooks',
 	'params' => array(),
@@ -29,7 +29,7 @@ $hook['post_controller_constructor'][] = array(
 
 $hook['post_controller_constructor'][] = array(
 	'class' => 'Fuel_hooks',
-	'function' => 'offline',
+	'function' => 'dev_password',
 	'filename' => 'Fuel_hooks.php',
 	'filepath' => 'hooks',
 	'params' => array(),


### PR DESCRIPTION
* Updated the sequence of offline & dev_password being evaluated.
* Updated offline maintenance page doesn't required dev_password.
* Updated Fuel_hooks.offline to redirect to 'offline' page instead of rendering offline content.
* Added fuel config constant 'offline_allowed_uri' indicates pages allowed to access in offline mode.