### PR TITLE
Non super-admin users can edit users

### DIFF
--- a/fuel/modules/fuel/controllers/my_profile.php
+++ b/fuel/modules/fuel/controllers/my_profile.php
@@ -48,7 +48,7 @@ class My_profile extends Fuel_base_controller {
 		}
 
 		// remove active from field list to prevent them from updating it
-		unset($fields['active'], $fields['Permissions'], $fields['permissions'], $fields['is_invite']);
+		unset($fields['active'], $fields['Permissions'], $fields['permissions'], $fields['is_invite'], $fields['id']);
 
 		if ( ! empty($_POST))
 		{

--- a/fuel/modules/fuel/models/fuel_users_model.php
+++ b/fuel/modules/fuel/models/fuel_users_model.php
@@ -639,13 +639,13 @@ class Fuel_users_model extends Base_module_model {
 		$values = parent::normalize_save_values($record);
 		$CI =& get_instance();
 		$valid_user = $CI->fuel->auth->valid_user();
-		if(!isset($values['id']))
+		if (!isset($values['id']))
 		{
 			$values['id'] = $valid_user['id'];
 		}
 		return $values;
 	}
-	
+
 	// --------------------------------------------------------------------
 	
 	/**

--- a/fuel/modules/fuel/models/fuel_users_model.php
+++ b/fuel/modules/fuel/models/fuel_users_model.php
@@ -627,6 +627,25 @@ class Fuel_users_model extends Base_module_model {
 		return $values;
 	}
 
+	/**
+	 * Normalize the save data (and add the user ID)
+	 *
+	 * @access	public
+	 * @param	mixed	array of values to be saved (optional)
+	 * @return	array
+	 */
+	public function normalize_save_values($record = NULL)
+	{
+		$values = parent::normalize_save_values($record);
+		$CI =& get_instance();
+		$valid_user = $CI->fuel->auth->valid_user();
+		if(!isset($values['id']))
+		{
+			$values['id'] = $valid_user['id'];
+		}
+		return $values;
+	}
+	
 	// --------------------------------------------------------------------
 	
 	/**


### PR DESCRIPTION
Uncovered an issue where non-admin users can update the profile information for any user they like, including super admin users, simply by updating the hidden input field 'id' in /fuel/my_profile/edit. This has the effect of changing the username and password without any prior knowledge of either.

Steps to reproduce from a fresh install:

1. Login as admin user
2. Create new user 'dummy' with email address dummy@dummy.com and provide no privileges. Use 'dummy' as password.
3. Log out as admin
4. Log in as dummy using 'dummy' as password.
5. Click user name 'dummy' in top-right of screen.
6. Update 'id' field to use value '1' rather than '2'. You can do this by inspecting the HTML and updating, or converting the hidden fields to text fields using JS or a browser extension; it's pretty trivial. You'll need to submit a user name and email address which are unique to the database; for illustration's sake change the username to 'dummy1' and email address to dummy1@dummy.com. Also update the password so you know what it is.
7. Submit the form. You can check the database to see that user ID #1's username and email address are now updated to 'dummy1' and 'dummy1@dummy.com'.
8. Log out as dummy.
9. Log in as dummy1. You should have super admin privileges.

The change removes the user ID from the list of form fields displayed, and, before the record is saved, gets the user ID from the logged-in user. A small amount of testing suggests this doesn't seem to impact the process of creating/editing users as normal when logged in as an admin account.
