### PR TITLE
Issues spotted while debugging

### DIFF
--- a/fuel/modules/fuel/core/Router.php
+++ b/fuel/modules/fuel/core/Router.php
@@ -321,7 +321,6 @@ class Fuel_Router extends MX_Router
 
 	public function set_class($class)
 	{
-		$class = $class.$this->config->item('controller_suffix');
 		parent::set_class($class);
 	}
 }

--- a/fuel/modules/fuel/core/Router.php
+++ b/fuel/modules/fuel/core/Router.php
@@ -64,6 +64,8 @@ class Fuel_Router extends MX_Router
 {
 	// --------------------------------------------------------------------
 
+	private $located;
+
 	/**
 	 * Parse Routes
 	 *


### PR DESCRIPTION
I spotted some issues while I was debugging something else.

If you have a config item 'controller_suffix' it will be applied twice to the `$class` var. This is because it is concatenated once on the Fuel_Router and again in the MX_Router.

```
public function set_class($class)
{
	$class = $class.$this->config->item('controller_suffix');
	parent::set_class($class);
}
```
MX_Router::set_class() (line 236)

Also in the Fuel_Router there is a var called `$located`. This is a private var in the MX_Router class and is not explicitly defined at the top of the Fuel_Router class. This was not causing any code execution issues but it was showing as an error in my IDE because it was not defined.