### PR TITLE
Fix for multiple languages and blocks

### DIFF
--- a/fuel/modules/fuel/assets/js/fuel/custom_fields.js
+++ b/fuel/modules/fuel/assets/js/fuel/custom_fields.js
@@ -1260,7 +1260,8 @@ if (typeof(window.fuel.fields) == 'undefined'){
 				if (layout && layout.length){
 					//layout = layout.split('/').pop();
 					layout = layout.replace('/', ':');
-					url = jqx_config.fuelPath + '/blocks/layout_fields/' + layout + '/' + id+ '/english/';
+					var language = ($('#language').length) ? $('#language').val() : 'english';
+ +					url = jqx_config.fuelPath + '/blocks/layout_fields/' + layout + '/' + id+ '/' + language + '/';
 				}
 			}
 			


### PR DESCRIPTION
This fix is old, but overwritten in a later commit.
I found this in the history: https://github.com/daylightstudio/FUEL-CMS/commit/3027b34d96ae4b6207bcf69fad544c55831d3499?diff=unified
