### PR TITLE
Surround database name with ticks in USE statement in the MySQLi driver

### DIFF
--- a/fuel/modules/fuel/core/MY_DB_mysqli_driver.php
+++ b/fuel/modules/fuel/core/MY_DB_mysqli_driver.php
@@ -371,7 +371,7 @@ class MY_DB_mysqli_driver extends CI_DB_mysqli_driver {
 		// select the database
 		$db = $db[$active_group]['database'];
 
-		$use_sql = 'USE '.$db;
+		$use_sql = 'USE `'.$db.'`';
 
 		$CI->db->query($use_sql);
 		$sql_arr = explode(";\n", str_replace("\r\n", "\n", $sql));


### PR DESCRIPTION
This prevents errors when the selected database's name has characters such as dashes in it.

I noticed the `MY_DB_mysql_driver` class already uses back-ticks, but the `MY_DB_mysqli_driver` class does not.

## To reproduce:

- Create a database with a dash in the name, e.g. `foo-bar`.
- Set up FUEL-CMS, updating the `database.php` file with database details, leaving `mysqli` as the `dbdriver`.
- Generate a simple model `baz` to invoke the driver.

### Output:

```
C:\wamp64\www\FUEL-CMS>php index.php fuel/generate/simple baz

Database error: A Database Error Occurred

        Error Number: 1064
        You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-bar' at line 1
        USE foo-bar
        Filename: C:/wamp64/www/FUEL-CMS/fuel/modules/fuel/core/MY_DB_mysqli_driver.php
        Line Number: 376


C:\wamp64\www\FUEL-CMS>
```