### PR TITLE
Fix incompatible function declaration in advanced module template

### DIFF
--- a/fuel/modules/fuel/views/_generate/advanced/libraries/Fuel_{module}.php
+++ b/fuel/modules/fuel/views/_generate/advanced/libraries/Fuel_{module}.php
@@ -46,7 +46,7 @@ class Fuel_{module} extends Fuel_advanced_module {
 	 * @param	array	config preferences
 	 * @return	void
 	 */	
-	public function initialize($params)
+	public function initialize($params = array())
 	{
 		parent::initialize($params);
 		$this->set_params($this->_config);


### PR DESCRIPTION
This fixes an 'Incompatible declaration' error when accessing a generated advanced module.

## To reproduce:

1. Generate an advanced module `foo` by running `php index.php fuel/generate/advanced foo`.
2. Navigate to anywhere the module is initialized, for example the user guide at `<site_url>/fuel/site_docs`. The error should be visible where the module's documentation should be.

## Output:

```

A PHP Error was encountered

Severity: Runtime Notice

Message: Declaration of Fuel_foo::initialize() should be compatible with Fuel_advanced_module::initialize($params = Array)

Filename: libraries/Fuel_foo.php

Line Number: 61

Backtrace:

File: C:\wamp64\www\FUEL-CMS\fuel\modules\fuel\core\Loader.php
Line: 585
Function: _error_handler

File: C:\wamp64\www\FUEL-CMS\fuel\modules\fuel\core\Loader.php
Line: 585
Function: _ci_load_library

File: C:\wamp64\www\FUEL-CMS\fuel\modules\fuel\core\Loader.php
Line: 198
Function: _ci_load_library

File: C:\wamp64\www\FUEL-CMS\fuel\modules\fuel\core\Loader.php
Line: 448
Function: library

File: C:\wamp64\www\FUEL-CMS\fuel\modules\fuel\libraries\Fuel.php
Line: 492
Function: module_library

File: C:\wamp64\www\FUEL-CMS\fuel\modules\fuel\libraries\Fuel_modules.php
Line: 385
Function: __get

File: C:\wamp64\www\FUEL-CMS\fuel\modules\fuel\core\Loader.php(392) : eval()'d code
Line: 62
Function: advanced

File: C:\wamp64\www\FUEL-CMS\fuel\modules\fuel\core\Loader.php
Line: 392
Function: eval

File: C:\wamp64\www\FUEL-CMS\fuel\modules\fuel\core\Loader.php
Line: 323
Function: _ci_load

File: C:\wamp64\www\FUEL-CMS\fuel\modules\fuel\core\Loader.php
Line: 462
Function: view

File: C:\wamp64\www\FUEL-CMS\fuel\modules\fuel\controllers\Site_docs.php
Line: 34
Function: module_view

File: C:\wamp64\www\FUEL-CMS\index.php
Line: 364
Function: require_once
```