### PR TITLE
Add a PHPDoc for the $db field in MY_Model

### DIFF
--- a/fuel/modules/fuel/core/MY_Model.php
+++ b/fuel/modules/fuel/core/MY_Model.php
@@ -67,7 +67,11 @@ class MY_Model extends CI_Model {
 	public $custom_fields = array(); // an array of field names/types that map to a specific class
 	public $formatters = array(); // an array of helper formatter functions related to a specific field type (e.g. string, datetime, number), or name (e.g. title, content) that can augment field results
 
-	protected $db; // CI database object
+    /**
+     * @var CI_DB_query_builder CI database query builder
+     */
+    protected $db;
+
 	protected $table_name; // the table name to associate the model with
 	protected $key_field = 'id'; // usually the tables primary key(s)... can be an array if compound key
 	protected $normalized_save_data = NULL; // the saved data before it is cleaned

--- a/fuel/modules/fuel/core/MY_Model.php
+++ b/fuel/modules/fuel/core/MY_Model.php
@@ -67,10 +67,10 @@ class MY_Model extends CI_Model {
 	public $custom_fields = array(); // an array of field names/types that map to a specific class
 	public $formatters = array(); // an array of helper formatter functions related to a specific field type (e.g. string, datetime, number), or name (e.g. title, content) that can augment field results
 
-    /**
-     * @var CI_DB_query_builder CI database query builder
-     */
-    protected $db;
+	/**
+	 * @var CI_DB_query_builder CI database query builder
+	 */
+	protected $db;
 
 	protected $table_name; // the table name to associate the model with
 	protected $key_field = 'id'; // usually the tables primary key(s)... can be an array if compound key


### PR DESCRIPTION
Adds no more than a PHPDoc for the `db` field in `MY_Model` class.

With this additional type information in place IDEs can help users with auto-completion.

See attached screenshot from PhpStorm below (before & after):

![ci-db-phpdoc-before-after](https://user-images.githubusercontent.com/3257241/33192999-4e9234fa-d0bd-11e7-983a-a5d5ed483cca.png)