### PR TITLE
Fix UTF-8 display in Excel

### DIFF
--- a/fuel/modules/fuel/config/fuel.php
+++ b/fuel/modules/fuel/config/fuel.php
@@ -107,6 +107,8 @@ $config['text_editor'] = 'markitup';
 // An associative array of objects to attach to the fuel object
 $config['attach'] = array();
 
+// Indicates whether a UTF-8 Byte Order Mark should be added to exported CSVs
+$config['export_utf8_bom'] = FALSE;
 
 /*
 |--------------------------------------------------------------------------

--- a/fuel/modules/fuel/config/fuel.php
+++ b/fuel/modules/fuel/config/fuel.php
@@ -107,9 +107,6 @@ $config['text_editor'] = 'markitup';
 // An associative array of objects to attach to the fuel object
 $config['attach'] = array();
 
-// Indicates whether a UTF-8 Byte Order Mark should be added to exported CSVs
-$config['export_utf8_bom'] = FALSE;
-
 /*
 |--------------------------------------------------------------------------
 | Language settings 

--- a/fuel/modules/fuel/controllers/Module.php
+++ b/fuel/modules/fuel/controllers/Module.php
@@ -2040,7 +2040,7 @@ class Module extends Fuel_base_controller {
 			$this->_filter_list($params);
 			$data = $this->model->export_data($params);
 
-			if ($this->fuel->config('export_utf8_bom')) {
+			if ($this->export_utf8_bom) {
 				// Add Byte Order Mark to fix UTF-8 in Excel
 				$utf8bom = chr(239) . chr(187) . chr(191);
 				$data = $utf8bom.$data;

--- a/fuel/modules/fuel/controllers/Module.php
+++ b/fuel/modules/fuel/controllers/Module.php
@@ -2040,6 +2040,12 @@ class Module extends Fuel_base_controller {
 			$this->_filter_list($params);
 			$data = $this->model->export_data($params);
 
+			if ($this->fuel->config('export_utf8_bom')) {
+				// Add Byte Order Mark to fix UTF-8 in Excel
+				$utf8bom = chr(239) . chr(187) . chr(191);
+				$data = $utf8bom.$data;
+			}
+
 			force_download($filename, $data);
 		}
 	}

--- a/fuel/modules/fuel/libraries/Fuel_modules.php
+++ b/fuel/modules/fuel/libraries/Fuel_modules.php
@@ -686,6 +686,7 @@ class Fuel_module extends Fuel_base_library {
 				'icon_class' => '',
 				'folder' => '',
 				'exportable' => FALSE,
+				'export_utf8_bom' => FALSE,
 				'limit_options' => array('50' => '50', '100' => '100', '200' => '200'),
 				'advanced_search' => FALSE,
 				'disable_heading_sort' => FALSE,

--- a/fuel/modules/fuel/views/_docs/modules/simple.php
+++ b/fuel/modules/fuel/views/_docs/modules/simple.php
@@ -283,12 +283,12 @@ on the key value specified in the config (e.g. example):</p>
 			<td>Boolean Value TRUE/FALSE</td>
 			<td>Will display an "Export" button on the list view page that will allow users to export the currently filtered list data</td>
 		</tr>
-        <tr>
-            <td><strong>export_utf8_bom</strong></td>
-            <td>FALSE</td>
-            <td>Boolean Value TRUE/FALSE</td>
-            <td>If TRUE, writes a Byte Order Mark (BOM) to CSV files before data. A BOM is needed in order to display UTF-8 characters correctly in applications such as Microsoft Excel</td>
-        </tr>
+		<tr>
+			<td><strong>export_utf8_bom</strong></td>
+			<td>FALSE</td>
+			<td>Boolean Value TRUE/FALSE</td>
+			<td>If TRUE, writes a Byte Order Mark (BOM) to CSV files before data. A BOM is needed in order to display UTF-8 characters correctly in applications such as Microsoft Excel</td>
+		</tr>
 		<tr>
 			<td><strong>limit_options</strong></td>
 			<td>array('25' => '25', '50' => '50', '100' => '100')</td>

--- a/fuel/modules/fuel/views/_docs/modules/simple.php
+++ b/fuel/modules/fuel/views/_docs/modules/simple.php
@@ -283,6 +283,12 @@ on the key value specified in the config (e.g. example):</p>
 			<td>Boolean Value TRUE/FALSE</td>
 			<td>Will display an "Export" button on the list view page that will allow users to export the currently filtered list data</td>
 		</tr>
+        <tr>
+            <td><strong>export_utf8_bom</strong></td>
+            <td>FALSE</td>
+            <td>Boolean Value TRUE/FALSE</td>
+            <td>If TRUE, writes a Byte Order Mark (BOM) to CSV files before data. A BOM is needed in order to display UTF-8 characters correctly in applications such as Microsoft Excel</td>
+        </tr>
 		<tr>
 			<td><strong>limit_options</strong></td>
 			<td>array('25' => '25', '50' => '50', '100' => '100')</td>


### PR DESCRIPTION
When users export a module's data using the "Export Data" button, if any of the columns have UTF-8 characters they will not be displayed properly in Microsoft Excel. This is because Excel requires a Byte Order Mark (BOM).

This adds the BOM before model data (if the config value `export_utf8_bom` is set to `TRUE`), fixing the output.

I am not sure what the default configuration value should be. Left it at `FALSE` to preserve backwards compatibility, as some people might still be using viewers that don't understand BOMs.

Another thing to consider is whether the config value should be `export_utf8_bom`, or a nested array with a top level `export` key.