### PR TITLE
Prevent infinite recursion if 'fuel' is specified as an allowed module

### DIFF
--- a/fuel/modules/fuel/config/fuel_routes.php
+++ b/fuel/modules/fuel/config/fuel_routes.php
@@ -17,9 +17,11 @@ include(FUEL_PATH.'config/fuel.php');
 // Load any public routes for advanced modules
 foreach ($config['modules_allowed'] as $module)
 {
-	$routes_path = $module_folder.$module.'/config/'.$module.'_routes.php';
-
-	if (file_exists($routes_path)) include($routes_path);
+	if ($module != FUEL_FOLDER) // Avoid infinite recursion
+	{
+		$routes_path = $module_folder.$module.'/config/'.$module.'_routes.php';
+		if (file_exists($routes_path)) include($routes_path);
+	}
 }
 
 // To prevent the overhead of this on every request, we do a quick check of the path... USE_FUEL_ROUTES is defined in fuel_constants


### PR DESCRIPTION
If people enter "fuel" as an allowed module in `config.php`, they'll be met with infinite recursion.

It seems the framework doesn't have a centralised handler of config values at the moment, so nothing prevents people from putting 'fuel' there. I stumbled upon this as I was playing around with the CLI.

An easy fix is to just check the module name and skip loading its routes if it is the `fuel` module.

## To reproduce:
* add `fuel` to the allowed modules array:

```
$config['modules_allowed'] = array(
    'user_guide',
    'fuel',
);
```
* load any page