### PR TITLE
Fix several small issues with Events_model example file

### DIFF
--- a/fuel/modules/fuel/views/_generate/model/Events_model.php
+++ b/fuel/modules/fuel/views/_generate/model/Events_model.php
@@ -63,6 +63,7 @@ class Events_model extends Base_posts_model {
 			}
 			return $str;
 		}
+		return array();
 	}
 
 	public function find_upcoming($limit = NULL)

--- a/fuel/modules/fuel/views/_generate/model/Events_model.php
+++ b/fuel/modules/fuel/views/_generate/model/Events_model.php
@@ -134,7 +134,7 @@ class Event_model extends Base_post_item_model {
 		// if a query string is passed, then we parse it into an array form
 		if (is_string($params))
 		{
-			$params = parse_str($params);
+			parse_str($params, $params);
 		}
 		
 		// defaults

--- a/fuel/modules/fuel/views/_generate/model/Events_model.php
+++ b/fuel/modules/fuel/views/_generate/model/Events_model.php
@@ -49,7 +49,7 @@ class Events_model extends Base_posts_model {
 		return $data;
 	}
 
-	public function related_items($params)
+	public function related_items($params = array())
 	{
 		if (!empty($params['id']))
 		{


### PR DESCRIPTION
- Incompatible function declaration does not match that of super class (`related_items`);
- Method `related_items` says it returns an array or string, but can return null, as well;
- Incorrect usage of `parse_str`. It is a `void` method and parses the first argument into the second.