### PR TITLE
Fix incorrect usage of 'parse_str' in Google helper

### DIFF
--- a/fuel/modules/fuel/helpers/google_helper.php
+++ b/fuel/modules/fuel/helpers/google_helper.php
@@ -236,7 +236,7 @@ if (!function_exists('google_map_url'))
 		// if a query string is passed, then we parse it into an array form
 		if (is_string($params))
 		{
-			$params = parse_str($params);
+			parse_str($params, $params);
 		}
 
 		// initialize the parameter array


### PR DESCRIPTION
Found another rogue `parse_str` use where FUEL CMS attempts to get a value back, even though the function returns `void`.

`parse_str` instead writes the updated value into the second argument.