### PR TITLE
Google helper address fix

### DIFF
--- a/fuel/modules/fuel/helpers/google_helper.php
+++ b/fuel/modules/fuel/helpers/google_helper.php
@@ -327,7 +327,6 @@ if (!function_exists('google_map_url'))
 		// set output
 		$p['output'] = 'embed';
 		$url = 'http://maps.google.com/maps?'.http_build_query($p, '', '&amp;');
-		$query_str = http_build_query($p, '', '&amp;');
 		return $url;
 	}
 }

--- a/fuel/modules/fuel/helpers/google_helper.php
+++ b/fuel/modules/fuel/helpers/google_helper.php
@@ -254,9 +254,8 @@ if (!function_exists('google_map_url'))
 				}
 				if (!empty($address['state']))
 				{
-					$addr .= ','.$address['state'];	
+					$p['q'] .= ','.$address['state'];
 				}
-				$p['q'] = $addr;
 			}
 			else
 			{


### PR DESCRIPTION
When using the Google helper, if an address is specified, PHP blows up with an error:

```
A PHP Error was encountered

Severity: Notice

Message: Undefined variable: addr

Filename: helpers/google_helper.php

Line Number: 257

Backtrace:

File: C:\wamp64\www\fuelcms\fuel\modules\fuel\helpers\google_helper.php
Line: 257
Function: _error_handler

File: C:\wamp64\www\fuelcms\fuel\application\controllers\Site.php
Line: 32
Function: google_map_url

File: C:\wamp64\www\fuelcms\index.php
Line: 364
Function: require_once
```

FUEL CMS tries to append the supplied state to a non-existent `addr` variable.

Instead we want to keep attaching data to `$p['q']`.