### PR TITLE
Move helper function PHPDocs inside 'function_exists' checks to help IDEs

### DIFF
--- a/fuel/modules/fuel/helpers/MY_array_helper.php
+++ b/fuel/modules/fuel/helpers/MY_array_helper.php
@@ -212,7 +212,6 @@ if ( ! function_exists('parse_string_to_array'))
 			}
 		}
 		return $params;
-		
 	}
 }
 

--- a/fuel/modules/fuel/helpers/MY_array_helper.php
+++ b/fuel/modules/fuel/helpers/MY_array_helper.php
@@ -35,9 +35,9 @@ if ( ! function_exists('array_orderby'))
 	 * An alternative array sorter that is a bit faster then array_sorter
 	 *
 	 * @access	public
-	 * @param	array 	The array of data
-	 * @param	string 	The column to sort by
-	 * @param	string 	The direction (asc/desc)
+	 * @param	array	The array of data
+	 * @param	string	The column to sort by
+	 * @param	string	The direction (asc/desc)
 	 * @return	array
 	 */
 	function array_orderby()
@@ -246,10 +246,10 @@ if ( ! function_exists('csv_to_array'))
 	 * Converts a .csv file to an associative array. Must have header row.
 	 *
 	 * @access	public
-	 * @param	string  file name
-	 * @param	string  the delimiter that separates each column
-	 * @param	int     the index for where the header row starts
-	 * @param	int     must be greater then the maximum line length. Setting to 0 is slightly slower, but works for any length
+	 * @param	string	file name
+	 * @param	string	the delimiter that separates each column
+	 * @param	int		the index for where the header row starts
+	 * @param	int		must be greater then the maximum line length. Setting to 0 is slightly slower, but works for any length
 	 * @return	array
 	 */
 	function csv_to_array($filename = '', $delimiter =  ',', $header_row = 0, $length = 0)
@@ -293,10 +293,10 @@ if ( ! function_exists('array_get'))
 	 * credit: borrowed from Vanilla forums GetValueR function
 	 *
 	 * @access	public
-	 * @param 	mixed $array The array or object to search.
-	 * @param 	string $key The key or property name of the value.
-	 * @param 	mixed $default The value to return if the key does not exist.
-	 * @return 	mixed The value from the array or object.
+	 * @param	mixed	$array		The array or object to search.
+	 * @param	string	$key		The key or property name of the value.
+	 * @param	mixed	$default	The value to return if the key does not exist.
+	 * @return	mixed				The value from the array or object.
 	 */
 	function array_get($array, $key, $default = FALSE)
 	{

--- a/fuel/modules/fuel/helpers/MY_array_helper.php
+++ b/fuel/modules/fuel/helpers/MY_array_helper.php
@@ -28,19 +28,18 @@
 
 // --------------------------------------------------------------------
 
-/**
- * An alternative array sorter that is a bit faster then array_sorter
- *
- * @access	public
- * @param	array 	The array of data
- * @param	string 	The column to sort by
- * @param	string 	The direction (asc/desc)
- * @return	array
- */
-
 if ( ! function_exists('array_orderby'))
 {
 	// http://php.net/manual/en/function.array-multisort.php
+	/**
+	 * An alternative array sorter that is a bit faster then array_sorter
+	 *
+	 * @access	public
+	 * @param	array 	The array of data
+	 * @param	string 	The column to sort by
+	 * @param	string 	The direction (asc/desc)
+	 * @return	array
+	 */
 	function array_orderby()
 	{
 		$args = func_get_args();
@@ -61,19 +60,19 @@ if ( ! function_exists('array_orderby'))
 
 // --------------------------------------------------------------------
 
-/**
- * Array sorter that will sort on an array's key and allows for asc/desc order
- *
- * @access	public
- * @param	array
- * @param	string
- * @param	string
- * @param	boolean
- * @param	boolean
- * @return	array
- */
 if ( ! function_exists('array_sorter'))
 {
+	/**
+	 * Array sorter that will sort on an array's key and allows for asc/desc order
+	 *
+	 * @access	public
+	 * @param	array
+	 * @param	string
+	 * @param	string
+	 * @param	boolean
+	 * @param	boolean
+	 * @return	array
+	 */
 	function array_sorter(&$array, $index, $order = 'asc', $nat_sort = FALSE, $case_sensitive = FALSE)
 	{
 		if(is_array($array) && count($array) > 0)
@@ -103,18 +102,18 @@ if ( ! function_exists('array_sorter'))
 
 // --------------------------------------------------------------------
 
-/**
- * Array sorter that will sort an array of objects based on an objects 
- * property and allows for asc/desc order. Changes the original object
- *
- * @access	public
- * @param	mixed
- * @param	string
- * @param	string
- * @return	NULL
- */
 if ( ! function_exists('object_sorter'))
 {
+	/**
+	 * Array sorter that will sort an array of objects based on an objects
+	 * property and allows for asc/desc order. Changes the original object
+	 *
+	 * @access	public
+	 * @param	mixed
+	 * @param	string
+	 * @param	string
+	 * @return	NULL
+	 */
 	function object_sorter(&$data, $key, $order = 'asc')
 	{
 		for ($i = count($data) - 1; $i >= 0; $i--)
@@ -152,21 +151,21 @@ if ( ! function_exists('object_sorter'))
 
 // --------------------------------------------------------------------
 
-/**
- * Creates a key/value array based on an original array.
- *
- * Can be used in conjunction with the Form library class 
- * (e.g. $this->form->select('countries, option_list($options)))
- *
- * @access	public
- * @param	array
- * @param	string
- * @param	string
- * @param	boolean
- * @return	array
- */
 if ( ! function_exists('options_list'))
 {
+	/**
+	 * Creates a key/value array based on an original array.
+	 *
+	 * Can be used in conjunction with the Form library class
+	 * (e.g. $this->form->select('countries, option_list($options)))
+	 *
+	 * @access	public
+	 * @param	array
+	 * @param	string
+	 * @param	string
+	 * @param	boolean
+	 * @return	array
+	 */
 	function options_list($values, $value = 'id', $label = 'name', $value_as_key = FALSE)
 	{
 		$return = array();
@@ -192,15 +191,15 @@ if ( ! function_exists('options_list'))
 
 // --------------------------------------------------------------------
 
-/**
- * Parses a string in the format of key1="val1" key2="val2" into an array
- *
- * @access	public
- * @param	string
- * @return	array
- */
 if ( ! function_exists('parse_string_to_array'))
 {
+	/**
+	 * Parses a string in the format of key1="val1" key2="val2" into an array
+	 *
+	 * @access	public
+	 * @param	string
+	 * @return	array
+	 */
 	function parse_string_to_array($str)
 	{
 		preg_match_all('#(\w+)=([\'"])(.*)\\2#U', $str, $matches);
@@ -217,16 +216,16 @@ if ( ! function_exists('parse_string_to_array'))
 	}
 }
 
-/**
- * Returns an array of arrays.
- *
- * @access	public
- * @param	array an array to be divided
- * @param	int number of groups to divide the array into
- * @return	array
- */	
 if ( ! function_exists('array_group'))
 {
+	/**
+	 * Returns an array of arrays.
+	 *
+	 * @access	public
+	 * @param	array an array to be divided
+	 * @param	int number of groups to divide the array into
+	 * @return	array
+	 */
 	function array_group($array, $groups)
 	{
 		if (empty($array))
@@ -238,18 +237,18 @@ if ( ! function_exists('array_group'))
 	}
 }
 
-/**
- * Converts a .csv file to an associative array. Must have header row.
- *
- * @access	public
- * @param	string  file name
- * @param	string  the delimiter that separates each column
- * @param	int     the index for where the header row starts
- * @param	int     must be greater then the maximum line length. Setting to 0 is slightly slower, but works for any length
- * @return	array
- */	
 if ( ! function_exists('csv_to_array'))
 {
+	/**
+	 * Converts a .csv file to an associative array. Must have header row.
+	 *
+	 * @access	public
+	 * @param	string  file name
+	 * @param	string  the delimiter that separates each column
+	 * @param	int     the index for where the header row starts
+	 * @param	int     must be greater then the maximum line length. Setting to 0 is slightly slower, but works for any length
+	 * @return	array
+	 */
 	function csv_to_array($filename = '', $delimiter =  ',', $header_row = 0, $length = 0)
 	{
 		if(!file_exists($filename) || !is_readable($filename))
@@ -284,18 +283,18 @@ if ( ! function_exists('csv_to_array'))
 
 // --------------------------------------------------------------------
 
-/**
- * Return the value from an associative array or an object.
- * credit: borrowed from Vanilla forums GetValueR function
- *
- * @access	public
- * @param 	mixed $array The array or object to search.
- * @param 	string $key The key or property name of the value.
- * @param 	mixed $default The value to return if the key does not exist.
- * @return 	mixed The value from the array or object.
- */
 if ( ! function_exists('array_get'))
 {
+	/**
+	 * Return the value from an associative array or an object.
+	 * credit: borrowed from Vanilla forums GetValueR function
+	 *
+	 * @access	public
+	 * @param 	mixed $array The array or object to search.
+	 * @param 	string $key The key or property name of the value.
+	 * @param 	mixed $default The value to return if the key does not exist.
+	 * @return 	mixed The value from the array or object.
+	 */
 	function array_get($array, $key, $default = FALSE)
 	{
 		$path = explode('.', $key);

--- a/fuel/modules/fuel/helpers/MY_array_helper.php
+++ b/fuel/modules/fuel/helpers/MY_array_helper.php
@@ -216,6 +216,8 @@ if ( ! function_exists('parse_string_to_array'))
 	}
 }
 
+// --------------------------------------------------------------------
+
 if ( ! function_exists('array_group'))
 {
 	/**
@@ -236,6 +238,8 @@ if ( ! function_exists('array_group'))
 		return array_chunk($array, $items_in_each_group);
 	}
 }
+
+// --------------------------------------------------------------------
 
 if ( ! function_exists('csv_to_array'))
 {

--- a/fuel/modules/fuel/helpers/MY_date_helper.php
+++ b/fuel/modules/fuel/helpers/MY_date_helper.php
@@ -213,7 +213,7 @@ if (!function_exists('time_verbose'))
 	/**
 	 * Returns the time into a verbose format (e.g. 12hrs 10mins 10secs)
 	 *
-	 * must be passed a string in hh:mm format
+	 * Must be passed a string in hh:mm format
 	 *
 	 * @access	public
 	 * @param	string
@@ -570,7 +570,7 @@ if (!function_exists('timestamp'))
 	 * Returns a timestamp from the provided time
 	 *
 	 * @access	public
-	 * @param	string date (optional)
+	 * @param	string	date (optional)
 	 * @return	string
 	 */
 	function timestamp($date = NULL)
@@ -592,8 +592,8 @@ if (!function_exists('month'))
 	 * Returns the month value of a provided date
 	 *
 	 * @access	public
-	 * @param	string date (optional)
-	 * @param	string options are 'm/numeric', 'F/long', 'M/short' <- default  (optional)
+	 * @param	string	date (optional)
+	 * @param	string	options are 'm/numeric', 'F/long', 'M/short' <- default  (optional)
 	 * @return	string
 	 */
 	function month($date = NULL, $format = 'M')
@@ -621,8 +621,8 @@ if (!function_exists('day'))
 	 * Returns the day value of a provided date
 	 *
 	 * @access	public
-	 * @param	string date (optional)
-	 * @param	string options are 'd/leading', 'j' <- default  (optional)
+	 * @param	string	date (optional)
+	 * @param	string	options are 'd/leading', 'j' <- default  (optional)
 	 * @return	string
 	 */
 	function day($date = NULL, $format = 'j')
@@ -645,8 +645,8 @@ if (!function_exists('weekday'))
 	 * Returns the weekday value of a provided date
 	 *
 	 * @access	public
-	 * @param	string date (optional)
-	 * @param	string options are 'l/full', 'N/numeric', 'D' <- default (optional)
+	 * @param	string	date (optional)
+	 * @param	string	options are 'l/full', 'N/numeric', 'D' <- default (optional)
 	 * @return	string
 	 */
 	function weekday($date = NULL, $format = 'D')
@@ -672,8 +672,8 @@ if (!function_exists('year'))
 	 * Returns the year value of a provided date
 	 *
 	 * @access	public
-	 * @param	string date (optional)
-	 * @param	string options are 'y/short', 'Y/long' <- default (optional)
+	 * @param	string	date (optional)
+	 * @param	string	options are 'y/short', 'Y/long' <- default (optional)
 	 * @return	string
 	 */
 	function year($date = NULL, $format = 'Y')
@@ -697,8 +697,8 @@ if (!function_exists('hour'))
 	 * Returns the hour value of a provided date
 	 *
 	 * @access	public
-	 * @param	string date (optional)
-	 * @param	string options are '24/military', '12' <- default (optional)
+	 * @param	string	date (optional)
+	 * @param	string	options are '24/military', '12' <- default (optional)
 	 * @return	string
 	 */
 	function hour($date = NULL, $format = '12')
@@ -722,8 +722,8 @@ if (!function_exists('minute'))
 	 * Returns the minute value of a provided date
 	 *
 	 * @access	public
-	 * @param	string date (optional)
-	 * @param	string options are 'noleading', 'leading' <- default (optional)
+	 * @param	string	date (optional)
+	 * @param	string	options are 'noleading', 'leading' <- default (optional)
 	 * @return	string
 	 */
 	function minute($date = NULL, $format = 'leading')
@@ -745,8 +745,8 @@ if (!function_exists('second'))
 	 * Returns the second value of a provided date
 	 *
 	 * @access	public
-	 * @param	string date (optional)
-	 * @param	string options are 'noleading', 'leading' <- default (optional)
+	 * @param	string	date (optional)
+	 * @param	string	options are 'noleading', 'leading' <- default (optional)
 	 * @return	string
 	 */
 	function second($date = NULL, $format = 'leading')
@@ -768,8 +768,8 @@ if (!function_exists('ampm'))
 	 * Returns the ampm value of a provided date
 	 *
 	 * @access	public
-	 * @param	string date (optional)
-	 * @param	string options are 'A/upper/uppercase', 'a/lower/lowercase' <- default (optional)
+	 * @param	string	date (optional)
+	 * @param	string	options are 'A/upper/uppercase', 'a/lower/lowercase' <- default (optional)
 	 * @return	string
 	 */
 	function ampm($date = NULL, $format = 'a')
@@ -793,7 +793,7 @@ if (!function_exists('is_midnight'))
 	 * Determines whether the time is midnight or not. Helps with dates that are set without time values
 	 *
 	 * @access	public
-	 * @param	string date
+	 * @param	string	date
 	 * @return	string
 	 */
 	function is_midnight($date)

--- a/fuel/modules/fuel/helpers/MY_date_helper.php
+++ b/fuel/modules/fuel/helpers/MY_date_helper.php
@@ -29,16 +29,16 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Returns the date into a specified format. Will look at the configuration
- *
- * @access	public'
- * @param	string
- * @param	mixed
- * @return	string
- */
 if (!function_exists('date_formatter'))
 {
+	/**
+	 * Returns the date into a specified format. Will look at the configuration
+	 *
+	 * @access	public'
+	 * @param	string
+	 * @param	mixed
+	 * @return	string
+	 */
 	function date_formatter($date, $format = FALSE)
 	{
 		$date_ts = strtotime($date);
@@ -65,15 +65,15 @@ if (!function_exists('date_formatter'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns the current datetime value in MySQL format
- *
- * @access	public
- * @param	boolean
- * @return	string
- */
 if (!function_exists('datetime_now'))
 {
+	/**
+	 * Returns the current datetime value in MySQL format
+	 *
+	 * @access	public
+	 * @param	boolean
+	 * @return	string
+	 */
 	function datetime_now($hms = TRUE)
 	{
 		if ($hms)
@@ -89,15 +89,15 @@ if (!function_exists('datetime_now'))
 
 // --------------------------------------------------------------------
 
-/**
- * Test for common date format
- *
- * @access	public
- * @param	string
- * @return	boolean
- */
 if (!function_exists('is_date_format'))
 {
+	/**
+	 * Test for common date format
+	 *
+	 * @access	public
+	 * @param	string
+	 * @return	boolean
+	 */
 	function is_date_format($date)
 	{
 		return (is_string($date) AND (!empty($date) AND (int)$date != 0) AND 
@@ -107,15 +107,15 @@ if (!function_exists('is_date_format'))
 
 // --------------------------------------------------------------------
 
-/**
- * Test for MySQL date format
- *
- * @access	public
- * @param	string
- * @return	boolean
- */
 if (!function_exists('is_date_db_format'))
 {
+	/**
+	 * Test for MySQL date format
+	 *
+	 * @access	public
+	 * @param	string
+	 * @return	boolean
+	 */
 	function is_date_db_format($date)
 	{
 		return preg_match("#([0-9]{4})-([0-9]{1,2})-([0-9]{1,2})#", $date);
@@ -124,15 +124,15 @@ if (!function_exists('is_date_db_format'))
 
 // --------------------------------------------------------------------
 
-/**
- * Test for mm/dd/yyyy format
- *
- * @access	public
- * @param	string
- * @return	boolean
- */
 if (!function_exists('is_date_english_format'))
 {
+	/**
+	 * Test for mm/dd/yyyy format
+	 *
+	 * @access	public
+	 * @param	string
+	 * @return	boolean
+	 */
 	function is_date_english_format($date)
 	{
 		return preg_match("#([0-9]{1,2})/([0-9]{1,2})/([0-9]{4})#", $date) OR preg_match("#([0-9]{1,2})-([0-9]{1,2})-([0-9]{4})#", $date);
@@ -141,19 +141,19 @@ if (!function_exists('is_date_english_format'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns date in mm/dd/yyy format by default
- * Can be configured with a date_format config value
- *
- * @access	public
- * @param	string
- * @param	boolean
- * @param	string
- * @param	string
- * @return	string
- */
 if (!function_exists('english_date'))
 {
+	/**
+	 * Returns date in mm/dd/yyy format by default
+	 * Can be configured with a date_format config value
+	 *
+	 * @access	public
+	 * @param	string
+	 * @param	boolean
+	 * @param	string
+	 * @param	string
+	 * @return	string
+	 */
 	function english_date($date, $long = FALSE, $timezone = NULL, $delimiter = '/')
 	{
 		if (!is_numeric($date) AND !preg_match("/([0-9]{4})-([0-9]{1,2})-([0-9]{1,2})/", $date, $regs))
@@ -183,16 +183,16 @@ if (!function_exists('english_date'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns date in 'verbose' (e.g. Jan. 1, 2010) format
- * Can be configured with a date_format_verbose config value
- *
- * @access	public
- * @param	string
- * @return	boolean
- */
 if (!function_exists('english_date_verbose'))
 {
+	/**
+	 * Returns date in 'verbose' (e.g. Jan. 1, 2010) format
+	 * Can be configured with a date_format_verbose config value
+	 *
+	 * @access	public
+	 * @param	string
+	 * @return	boolean
+	 */
 	function english_date_verbose($date)
 	{
 		$date_ts = (!is_numeric($date)) ? strtotime($date) : $date;
@@ -209,18 +209,18 @@ if (!function_exists('english_date_verbose'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns the time into a verbose format (e.g. 12hrs 10mins 10secs)
- *
- * must be passed a string in hh:mm format
- *
- * @access	public
- * @param	string
- * @param	boolean
- * @return	boolean
- */
 if (!function_exists('time_verbose'))
 {
+	/**
+	 * Returns the time into a verbose format (e.g. 12hrs 10mins 10secs)
+	 *
+	 * must be passed a string in hh:mm format
+	 *
+	 * @access	public
+	 * @param	string
+	 * @param	boolean
+	 * @return	boolean
+	 */
 	function time_verbose($time, $include_seconds = FALSE)
 	{
 		if (is_date_format($time))
@@ -247,19 +247,19 @@ if (!function_exists('time_verbose'))
 
 // --------------------------------------------------------------------
 
-/**
- * Converts a date from english (e.g. mm/dd/yyyy) to db format (e.g yyyy-mm-dd)
- *
- * @access	public
- * @param	string
- * @param	int
- * @param	int
- * @param	int
- * @param	string
- * @return	string
- */
 if (!function_exists('english_date_to_db_format'))
 {
+	/**
+	 * Converts a date from english (e.g. mm/dd/yyyy) to db format (e.g yyyy-mm-dd)
+	 *
+	 * @access	public
+	 * @param	string
+	 * @param	int
+	 * @param	int
+	 * @param	int
+	 * @param	string
+	 * @return	string
+	 */
 	function english_date_to_db_format($date, $hour = 0, $min = 0, $sec = 0, $ampm = 'am')
 	{
 		$hour = (int) $hour;
@@ -313,21 +313,21 @@ if (!function_exists('english_date_to_db_format'))
 
 // --------------------------------------------------------------------
 
-/**
- * Formats a date into yyyy-mm-dd hh:mm:ss format
- *
- * @access	public
- * @param	int
- * @param	int
- * @param	int
- * @param	int
- * @param	int
- * @param	int
- * @return	string
- */
 // formats a date into a mysql date
 if (!function_exists('format_db_date'))
 {
+	/**
+	 * Formats a date into yyyy-mm-dd hh:mm:ss format
+	 *
+	 * @access	public
+	 * @param	int
+	 * @param	int
+	 * @param	int
+	 * @param	int
+	 * @param	int
+	 * @param	int
+	 * @return	string
+	 */
 	function format_db_date($y = NULL, $m = NULL, $d = NULL, $h = NULL, $i = NULL, $s = NULL)
 	{
 		if (empty($m) AND !empty($y))
@@ -364,17 +364,17 @@ if (!function_exists('format_db_date'))
 
 // --------------------------------------------------------------------
 
-/**
- * Creates a date range string (e.g. January 1-10, 2010)
- *
- * @access	public
- * @param	string start date
- * @param	string end date
- * @param	array formatting parameters
- * @return	string
- */
 if (!function_exists('date_range_string'))
 {
+	/**
+	 * Creates a date range string (e.g. January 1-10, 2010)
+	 *
+	 * @access	public
+	 * @param	string start date
+	 * @param	string end date
+	 * @param	array formatting parameters
+	 * @return	string
+	 */
 	function date_range_string($date1, $date2, $params = array())
 	{
 		
@@ -431,18 +431,18 @@ if (!function_exists('date_range_string'))
 
 // --------------------------------------------------------------------
 
-/**
- * Creates a string based on how long from the current time the date provided.
- * 
- * (e.g. 10 minutes ago)
- *
- * @access	public
- * @param	string
- * @param	booelan
- * @return	string
- */
 if (!function_exists('pretty_date'))
 {
+	/**
+	 * Creates a string based on how long from the current time the date provided.
+	 *
+	 * (e.g. 10 minutes ago)
+	 *
+	 * @access	public
+	 * @param	string
+	 * @param	booelan
+	 * @return	string
+	 */
 	function pretty_date($timestamp, $use_gmt = FALSE)
 	{
 		if (is_string($timestamp))
@@ -496,16 +496,16 @@ if (!function_exists('pretty_date'))
 
 // --------------------------------------------------------------------
 
-/**
- * Calculate the age between 2 dates
- *
- * @access	public
- * @param	int
- * @param	int
- * @return	string
- */
 if (!function_exists('get_age'))
 {
+	/**
+	 * Calculate the age between 2 dates
+	 *
+	 * @access	public
+	 * @param	int
+	 * @param	int
+	 * @return	string
+	 */
 	function get_age($bday_ts, $at_time_ts = NULL)  
 	{ 
 		if (empty($at_time_ts)) $at_time_ts = time();
@@ -528,19 +528,19 @@ if (!function_exists('get_age'))
 
 // ------------------------------------------------------------------------
 
-/**
- * Standard Date.. OVERWRITE CI version due to bugs
- *
- * Returns a date formatted according to the submitted standard.
- * http://codeigniter.com/forums/viewthread/171906/
- *
- * @access	public
- * @param	string	the chosen format
- * @param	int	Unix timestamp
- * @return	string
- */
 if (!function_exists('standard_date'))
 {
+	/**
+	 * Standard Date.. OVERWRITE CI version due to bugs
+	 *
+	 * Returns a date formatted according to the submitted standard.
+	 * http://codeigniter.com/forums/viewthread/171906/
+	 *
+	 * @access	public
+	 * @param	string	the chosen format
+	 * @param	int	Unix timestamp
+	 * @return	string
+	 */
 	function standard_date($fmt = 'DATE_RFC822', $time = '')
 	{
 		$formats = array(
@@ -566,15 +566,15 @@ if (!function_exists('standard_date'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a timestamp from the provided time
- *
- * @access	public
- * @param	string date (optional)
- * @return	string
- */
 if (!function_exists('timestamp'))
 {
+	/**
+	 * Returns a timestamp from the provided time
+	 *
+	 * @access	public
+	 * @param	string date (optional)
+	 * @return	string
+	 */
 	function timestamp($date = NULL)
 	{
 		if (empty($date))
@@ -588,16 +588,16 @@ if (!function_exists('timestamp'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a the month value of a provided date
- *
- * @access	public
- * @param	string date (optional)
- * @param	string options are 'm/numeric', 'F/long', 'M/short' <- default  (optional)
- * @return	string
- */
 if (!function_exists('month'))
 {
+	/**
+	 * Returns a the month value of a provided date
+	 *
+	 * @access	public
+	 * @param	string date (optional)
+	 * @param	string options are 'm/numeric', 'F/long', 'M/short' <- default  (optional)
+	 * @return	string
+	 */
 	function month($date = NULL, $format = 'M')
 	{
 		$ts = timestamp($date);
@@ -617,16 +617,16 @@ if (!function_exists('month'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a the day value of a provided date
- *
- * @access	public
- * @param	string date (optional)
- * @param	string options are 'd/leading', 'j' <- default  (optional)
- * @return	string
- */
 if (!function_exists('day'))
 {
+	/**
+	 * Returns a the day value of a provided date
+	 *
+	 * @access	public
+	 * @param	string date (optional)
+	 * @param	string options are 'd/leading', 'j' <- default  (optional)
+	 * @return	string
+	 */
 	function day($date = NULL, $format = 'j')
 	{
 		switch($format)
@@ -641,16 +641,16 @@ if (!function_exists('day'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a the weekday value of a provided date
- *
- * @access	public
- * @param	string date (optional)
- * @param	string options are 'l/full', 'N/numeric', 'D' <- default (optional)
- * @return	string
- */
 if (!function_exists('weekday'))
 {
+	/**
+	 * Returns a the weekday value of a provided date
+	 *
+	 * @access	public
+	 * @param	string date (optional)
+	 * @param	string options are 'l/full', 'N/numeric', 'D' <- default (optional)
+	 * @return	string
+	 */
 	function weekday($date = NULL, $format = 'D')
 	{
 		$ts = timestamp($date);
@@ -668,16 +668,16 @@ if (!function_exists('weekday'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a the year value of a provided date
- *
- * @access	public
- * @param	string date (optional)
- * @param	string options are 'y/short', 'Y/long' <- default (optional)
- * @return	string
- */
 if (!function_exists('year'))
 {
+	/**
+	 * Returns a the year value of a provided date
+	 *
+	 * @access	public
+	 * @param	string date (optional)
+	 * @param	string options are 'y/short', 'Y/long' <- default (optional)
+	 * @return	string
+	 */
 	function year($date = NULL, $format = 'Y')
 	{
 		$ts = timestamp($date);
@@ -693,16 +693,16 @@ if (!function_exists('year'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a the weekday value of a provided date
- *
- * @access	public
- * @param	string date (optional)
- * @param	string options are '24/military', '12' <- default (optional)
- * @return	string
- */
 if (!function_exists('hour'))
 {
+	/**
+	 * Returns a the weekday value of a provided date
+	 *
+	 * @access	public
+	 * @param	string date (optional)
+	 * @param	string options are '24/military', '12' <- default (optional)
+	 * @return	string
+	 */
 	function hour($date = NULL, $format = '12')
 	{
 		$ts = timestamp($date);
@@ -718,16 +718,16 @@ if (!function_exists('hour'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a the weekday value of a provided date
- *
- * @access	public
- * @param	string date (optional)
- * @param	string options are 'noleading', 'leading' <- default (optional)
- * @return	string
- */
 if (!function_exists('minute'))
 {
+	/**
+	 * Returns a the weekday value of a provided date
+	 *
+	 * @access	public
+	 * @param	string date (optional)
+	 * @param	string options are 'noleading', 'leading' <- default (optional)
+	 * @return	string
+	 */
 	function minute($date = NULL, $format = 'leading')
 	{
 		$min = date('i', timestamp($date));
@@ -741,16 +741,16 @@ if (!function_exists('minute'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a the weekday value of a provided date
- *
- * @access	public
- * @param	string date (optional)
- * @param	string options are 'noleading', 'leading' <- default (optional)
- * @return	string
- */
 if (!function_exists('second'))
 {
+	/**
+	 * Returns a the weekday value of a provided date
+	 *
+	 * @access	public
+	 * @param	string date (optional)
+	 * @param	string options are 'noleading', 'leading' <- default (optional)
+	 * @return	string
+	 */
 	function second($date = NULL, $format = 'leading')
 	{
 		$sec = date('s', timestamp($date));
@@ -764,16 +764,16 @@ if (!function_exists('second'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a the ampm value of a provided date
- *
- * @access	public
- * @param	string date (optional)
- * @param	string options are 'A/upper/uppercase', 'a/lower/lowercase' <- default (optional)
- * @return	string
- */
 if (!function_exists('ampm'))
 {
+	/**
+	 * Returns a the ampm value of a provided date
+	 *
+	 * @access	public
+	 * @param	string date (optional)
+	 * @param	string options are 'A/upper/uppercase', 'a/lower/lowercase' <- default (optional)
+	 * @return	string
+	 */
 	function ampm($date = NULL, $format = 'a')
 	{
 		$ts = timestamp($date);
@@ -789,15 +789,15 @@ if (!function_exists('ampm'))
 
 // --------------------------------------------------------------------
 
-/**
- * Determines whether the time is midnight or not. Helps with dates that are set without time values
- *
- * @access	public
- * @param	string date
- * @return	string
- */
 if (!function_exists('is_midnight'))
 {
+	/**
+	 * Determines whether the time is midnight or not. Helps with dates that are set without time values
+	 *
+	 * @access	public
+	 * @param	string date
+	 * @return	string
+	 */
 	function is_midnight($date)
 	{
 		$ts = timestamp($date);

--- a/fuel/modules/fuel/helpers/MY_date_helper.php
+++ b/fuel/modules/fuel/helpers/MY_date_helper.php
@@ -26,7 +26,6 @@
  * @link		http://docs.getfuelcms.com/helpers/my_date_helper
  */
 
-
 // --------------------------------------------------------------------
 
 if (!function_exists('date_formatter'))
@@ -191,7 +190,7 @@ if (!function_exists('english_date_verbose'))
 	 *
 	 * @access	public
 	 * @param	string
-	 * @return	boolean
+	 * @return	boolean|string
 	 */
 	function english_date_verbose($date)
 	{
@@ -377,7 +376,6 @@ if (!function_exists('date_range_string'))
 	 */
 	function date_range_string($date1, $date2, $params = array())
 	{
-		
 		// set formatting defaults
 		$format['same_day_and_time'] = 'F j, Y h:ia';
 		$format['same_day'] = array('F j, h:ia', 'h:ia');
@@ -440,7 +438,7 @@ if (!function_exists('pretty_date'))
 	 *
 	 * @access	public
 	 * @param	string
-	 * @param	booelan
+	 * @param	boolean
 	 * @return	string
 	 */
 	function pretty_date($timestamp, $use_gmt = FALSE)
@@ -591,7 +589,7 @@ if (!function_exists('timestamp'))
 if (!function_exists('month'))
 {
 	/**
-	 * Returns a the month value of a provided date
+	 * Returns the month value of a provided date
 	 *
 	 * @access	public
 	 * @param	string date (optional)
@@ -620,7 +618,7 @@ if (!function_exists('month'))
 if (!function_exists('day'))
 {
 	/**
-	 * Returns a the day value of a provided date
+	 * Returns the day value of a provided date
 	 *
 	 * @access	public
 	 * @param	string date (optional)
@@ -644,7 +642,7 @@ if (!function_exists('day'))
 if (!function_exists('weekday'))
 {
 	/**
-	 * Returns a the weekday value of a provided date
+	 * Returns the weekday value of a provided date
 	 *
 	 * @access	public
 	 * @param	string date (optional)
@@ -671,7 +669,7 @@ if (!function_exists('weekday'))
 if (!function_exists('year'))
 {
 	/**
-	 * Returns a the year value of a provided date
+	 * Returns the year value of a provided date
 	 *
 	 * @access	public
 	 * @param	string date (optional)
@@ -696,7 +694,7 @@ if (!function_exists('year'))
 if (!function_exists('hour'))
 {
 	/**
-	 * Returns a the weekday value of a provided date
+	 * Returns the hour value of a provided date
 	 *
 	 * @access	public
 	 * @param	string date (optional)
@@ -721,7 +719,7 @@ if (!function_exists('hour'))
 if (!function_exists('minute'))
 {
 	/**
-	 * Returns a the weekday value of a provided date
+	 * Returns the minute value of a provided date
 	 *
 	 * @access	public
 	 * @param	string date (optional)
@@ -744,7 +742,7 @@ if (!function_exists('minute'))
 if (!function_exists('second'))
 {
 	/**
-	 * Returns a the weekday value of a provided date
+	 * Returns the second value of a provided date
 	 *
 	 * @access	public
 	 * @param	string date (optional)
@@ -767,7 +765,7 @@ if (!function_exists('second'))
 if (!function_exists('ampm'))
 {
 	/**
-	 * Returns a the ampm value of a provided date
+	 * Returns the ampm value of a provided date
 	 *
 	 * @access	public
 	 * @param	string date (optional)

--- a/fuel/modules/fuel/helpers/MY_directory_helper.php
+++ b/fuel/modules/fuel/helpers/MY_directory_helper.php
@@ -32,16 +32,16 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Recursively copies from one directory to another
- *
- * @access	public
- * @param 	string
- * @param 	string
- * @return	array
- */
 if (!function_exists('copyr'))
 {
+	/**
+	 * Recursively copies from one directory to another
+	 *
+	 * @access	public
+	 * @param 	string
+	 * @param 	string
+	 * @return	array
+	 */
 	function copyr($source, $dest)
 	{
 		// Simple copy for a file
@@ -90,17 +90,17 @@ if (!function_exists('copyr'))
 
 // --------------------------------------------------------------------
 
-/**
- * Recursively changes the permissions of a folder structure
- *
- *  from php.net/chmod
- * @access	public
- * @param 	string
- * @param 	octal
- * @return	boolean
- */
 if (!function_exists('chmodr'))
 {
+	/**
+	 * Recursively changes the permissions of a folder structure
+	 *
+	 *  from php.net/chmod
+	 * @access	public
+	 * @param 	string
+	 * @param 	octal
+	 * @return	boolean
+	 */
 	function chmodr($path, $filemode) { 
 		if (!is_dir($path))
 		{
@@ -143,18 +143,18 @@ if (!function_exists('chmodr'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns an array of file names from a directory
- *
- * @access	public
- * @param 	string
- * @param 	boolean
- * @param 	mixed
- * @param 	boolean
- * @return	array
- */
 if (!function_exists('directory_to_array'))
 {
+	/**
+	 * Returns an array of file names from a directory
+	 *
+	 * @access	public
+	 * @param 	string
+	 * @param 	boolean
+	 * @param 	mixed
+	 * @param 	boolean
+	 * @return	array
+	 */
 	function directory_to_array($directory, $recursive = TRUE, $exclude = array(), $append_path = TRUE, $no_ext = FALSE, $_first_time = TRUE)
 	{
 		static $orig_directory;
@@ -198,20 +198,20 @@ if (!function_exists('directory_to_array'))
 
 // --------------------------------------------------------------------
 
-/**
- * Lists the directories only from a give directory
- *
- * @access	public
- * @param 	string
- * @param 	mixed
- * @param 	boolean
- * @param 	boolean
- * @param 	boolean
- * @param 	boolean
- * @return	array
- */
 if (!function_exists('list_directories'))
 {
+	/**
+	 * Lists the directories only from a give directory
+	 *
+	 * @access	public
+	 * @param 	string
+	 * @param 	mixed
+	 * @param 	boolean
+	 * @param 	boolean
+	 * @param 	boolean
+	 * @param 	boolean
+	 * @return	array
+	 */
 	function list_directories($directory, $exclude = array(), $full_path = TRUE, $is_writable = FALSE, $recursive = TRUE, $_first_time = TRUE)
 	{
 		static $orig_directory;

--- a/fuel/modules/fuel/helpers/MY_directory_helper.php
+++ b/fuel/modules/fuel/helpers/MY_directory_helper.php
@@ -37,8 +37,8 @@ if (!function_exists('copyr'))
 	 * Recursively copies from one directory to another
 	 *
 	 * @access	public
-	 * @param 	string
-	 * @param 	string
+	 * @param	string
+	 * @param	string
 	 * @return	boolean|array
 	 */
 	function copyr($source, $dest)
@@ -96,8 +96,8 @@ if (!function_exists('chmodr'))
 	 *
 	 *  from php.net/chmod
 	 * @access	public
-	 * @param 	string
-	 * @param 	int      file mode (octal value)
+	 * @param	string
+	 * @param	int		file mode (octal value)
 	 * @return	boolean
 	 */
 	function chmodr($path, $filemode) { 
@@ -148,10 +148,10 @@ if (!function_exists('directory_to_array'))
 	 * Returns an array of file names from a directory
 	 *
 	 * @access	public
-	 * @param 	string
-	 * @param 	boolean
-	 * @param 	mixed
-	 * @param 	boolean
+	 * @param	string
+	 * @param	boolean
+	 * @param	mixed
+	 * @param	boolean
 	 * @return	array
 	 */
 	function directory_to_array($directory, $recursive = TRUE, $exclude = array(), $append_path = TRUE, $no_ext = FALSE, $_first_time = TRUE)
@@ -203,12 +203,12 @@ if (!function_exists('list_directories'))
 	 * Lists the directories only from a given directory
 	 *
 	 * @access	public
-	 * @param 	string
-	 * @param 	mixed
-	 * @param 	boolean
-	 * @param 	boolean
-	 * @param 	boolean
-	 * @param 	boolean
+	 * @param	string
+	 * @param	mixed
+	 * @param	boolean
+	 * @param	boolean
+	 * @param	boolean
+	 * @param	boolean
 	 * @return	array
 	 */
 	function list_directories($directory, $exclude = array(), $full_path = TRUE, $is_writable = FALSE, $recursive = TRUE, $_first_time = TRUE)

--- a/fuel/modules/fuel/helpers/MY_directory_helper.php
+++ b/fuel/modules/fuel/helpers/MY_directory_helper.php
@@ -39,7 +39,7 @@ if (!function_exists('copyr'))
 	 * @access	public
 	 * @param 	string
 	 * @param 	string
-	 * @return	array
+	 * @return	boolean|array
 	 */
 	function copyr($source, $dest)
 	{
@@ -83,7 +83,7 @@ if (!function_exists('copyr'))
 
 		// Clean up
 		$dir->close();
-		return true;
+		return TRUE;
 	}
 }
 
@@ -97,7 +97,7 @@ if (!function_exists('chmodr'))
 	 *  from php.net/chmod
 	 * @access	public
 	 * @param 	string
-	 * @param 	octal
+	 * @param 	int      file mode (octal value)
 	 * @return	boolean
 	 */
 	function chmodr($path, $filemode) { 
@@ -200,7 +200,7 @@ if (!function_exists('directory_to_array'))
 if (!function_exists('list_directories'))
 {
 	/**
-	 * Lists the directories only from a give directory
+	 * Lists the directories only from a given directory
 	 *
 	 * @access	public
 	 * @param 	string
@@ -273,5 +273,6 @@ if (!function_exists('list_directories'))
 		return $dirs;
 	}
 }
+
 /* End of file MY_directory_helper.php */
 /* Location: ./modules/fuel/helpers/MY_directory_helper.php */

--- a/fuel/modules/fuel/helpers/MY_directory_helper.php
+++ b/fuel/modules/fuel/helpers/MY_directory_helper.php
@@ -29,7 +29,6 @@
  * @link		http://docs.getfuelcms.com/helpers/my_directory_helper
  */
 
-
 // --------------------------------------------------------------------
 
 if (!function_exists('copyr'))

--- a/fuel/modules/fuel/helpers/MY_file_helper.php
+++ b/fuel/modules/fuel/helpers/MY_file_helper.php
@@ -37,9 +37,9 @@ if (!function_exists('get_dir_file_info'))
 	 * Gets the directory file info.
 	 *
 	 * @access	public
-	 * @param 	string
-	 * @param 	boolean
-	 * @param 	boolean
+	 * @param	string
+	 * @param	boolean
+	 * @param	boolean
 	 * @return	array
 	 */
 	function get_dir_file_info($source_dir, $top_level_only = TRUE, $include_path = FALSE, $_recursion = FALSE)
@@ -100,10 +100,10 @@ if (!function_exists('delete_files'))
 	 * Deletes files in a directory with the added option to exclude certain files
 	 *
 	 * @access	public
-	 * @param 	string
-	 * @param 	boolean
-	 * @param 	mixed
-	 * @param 	int
+	 * @param	string
+	 * @param	boolean
+	 * @param	mixed
+	 * @param	int
 	 * @return	void
 	 */
 	function delete_files($path, $del_dir = FALSE, $exclude = NULL, $level = 0)
@@ -150,9 +150,9 @@ if (!function_exists('delete_old_files'))
 	 * Deletes files in a directory older then a certain date with the added option to exclude certain files
 	 *
 	 * @access	public
-	 * @param 	string
-	 * @param 	string
-	 * @param 	mixed
+	 * @param	string
+	 * @param	string
+	 * @param	mixed
 	 * @return	void
 	 */
 	function delete_old_files($dir, $older_than, $exclude = array())
@@ -183,7 +183,7 @@ if (!function_exists('is_image_file'))
 	 * Determines if the file is an image
 	 *
 	 * @access	public
-	 * @param 	string
+	 * @param	string
 	 * @return	boolean
 	 */
 	function is_image_file($path)

--- a/fuel/modules/fuel/helpers/MY_file_helper.php
+++ b/fuel/modules/fuel/helpers/MY_file_helper.php
@@ -32,17 +32,17 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Gets the directory file info.
- *
- * @access	public
- * @param 	string
- * @param 	boolean
- * @param 	boolean
- * @return	array
- */
 if (!function_exists('get_dir_file_info'))
 {
+	/**
+	 * Gets the directory file info.
+	 *
+	 * @access	public
+	 * @param 	string
+	 * @param 	boolean
+	 * @param 	boolean
+	 * @return	array
+	 */
 	function get_dir_file_info($source_dir, $top_level_only = TRUE, $include_path = FALSE, $_recursion = FALSE)
 	{
 		static $_filedata = array();
@@ -95,18 +95,18 @@ if (!function_exists('get_dir_file_info'))
 
 // --------------------------------------------------------------------
 
-/**
- * Deletes files in a directory with the added option to exclude certain files
- *
- * @access	public
- * @param 	string
- * @param 	boolean
- * @param 	mixed
- * @param 	int
- * @return	void
- */
 if (!function_exists('delete_files'))
 {
+	/**
+	 * Deletes files in a directory with the added option to exclude certain files
+	 *
+	 * @access	public
+	 * @param 	string
+	 * @param 	boolean
+	 * @param 	mixed
+	 * @param 	int
+	 * @return	void
+	 */
 	function delete_files($path, $del_dir = FALSE, $exclude = NULL, $level = 0)
 	{	
 		// Trim the trailing slash
@@ -145,17 +145,17 @@ if (!function_exists('delete_files'))
 
 // --------------------------------------------------------------------
 
-/**
- * Deletes files in a directory older then a certain date with the added option to exclude certain files
- *
- * @access	public
- * @param 	string
- * @param 	string
- * @param 	mixed
- * @return	void
- */
 if (!function_exists('delete_old_files'))
 {
+	/**
+	 * Deletes files in a directory older then a certain date with the added option to exclude certain files
+	 *
+	 * @access	public
+	 * @param 	string
+	 * @param 	string
+	 * @param 	mixed
+	 * @return	void
+	 */
 	function delete_old_files($dir, $older_than, $exclude = array())
 	{
 		$files = get_dir_file_info($dir);
@@ -178,15 +178,15 @@ if (!function_exists('delete_old_files'))
 
 // --------------------------------------------------------------------
 
-/**
- * Determines if the file is an image
- *
- * @access	public
- * @param 	string
- * @return	boolean
- */
 if (!function_exists('is_image_file'))
 {
+	/**
+	 * Determines if the file is an image
+	 *
+	 * @access	public
+	 * @param 	string
+	 * @return	boolean
+	 */
 	function is_image_file($path)
 	{
 		if (preg_match("/.+\\.(jpg|jpeg|jpe|gif|png)$/i",$path))

--- a/fuel/modules/fuel/helpers/MY_file_helper.php
+++ b/fuel/modules/fuel/helpers/MY_file_helper.php
@@ -195,5 +195,6 @@ if (!function_exists('is_image_file'))
 		return FALSE;
 	}
 }
+
 /* End of file MY_file_helper.php */
 /* Location: ./modules/fuel/helpers/MY_file_helper.php */

--- a/fuel/modules/fuel/helpers/MY_file_helper.php
+++ b/fuel/modules/fuel/helpers/MY_file_helper.php
@@ -29,7 +29,6 @@
  * @link		http://docs.getfuelcms.com/helpers/my_file_helper
  */
 
-
 // --------------------------------------------------------------------
 
 if (!function_exists('get_dir_file_info'))

--- a/fuel/modules/fuel/helpers/MY_html_helper.php
+++ b/fuel/modules/fuel/helpers/MY_html_helper.php
@@ -32,18 +32,18 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Wrap an string or array of values in opening and closing tag
- *
- * @access	public
- * @param 	string 	opening tag element
- * @param 	string 	closing tag element
- * @param 	mixed 	array of values to be enclosed by tags  
- * @param	boolean	echo to the screen
- * @return	string
- */
 if (!function_exists('tag'))
 {
+	/**
+	 * Wrap an string or array of values in opening and closing tag
+	 *
+	 * @access	public
+	 * @param 	string 	opening tag element
+	 * @param 	string 	closing tag element
+	 * @param 	mixed 	array of values to be enclosed by tags
+	 * @param	boolean	echo to the screen
+	 * @return	string
+	 */
 	function tag($tag, $vals, $attrs = array())
 	{
 		$str = '';
@@ -69,18 +69,18 @@ if (!function_exists('tag'))
 
 // --------------------------------------------------------------------
 
-/**
- * Wrap a string into an HTML blockquote with quotes and cite added
- *
- * @access	public
- * @param 	string 	string to be enclosed by quote elements
- * @param 	string 	string source value
- * @param 	string 	string company/position value 
- * @param 	string 	string css class 
- * @return	string
- */
 if (!function_exists('quote'))
 {
+	/**
+	 * Wrap a string into an HTML blockquote with quotes and cite added
+	 *
+	 * @access	public
+	 * @param 	string 	string to be enclosed by quote elements
+	 * @param 	string 	string source value
+	 * @param 	string 	string company/position value
+	 * @param 	string 	string css class
+	 * @return	string
+	 */
 	function quote($quote, $cite = NULL, $title = NULL, $class = 'quote')
 	{
 		$str = '<blockquote';
@@ -109,15 +109,15 @@ if (!function_exists('quote'))
 
 // --------------------------------------------------------------------
 
-/**
- * Create HTML attributes
- *
- * @access	public
- * @param 	mixed 	HTML attributs
- * @return	string
- */
 if (!function_exists('html_attrs'))
 {
+	/**
+	 * Create HTML attributes
+	 *
+	 * @access	public
+	 * @param 	mixed 	HTML attributs
+	 * @return	string
+	 */
 	function html_attrs($attrs)
 	{
 		if (is_array($attrs))

--- a/fuel/modules/fuel/helpers/MY_html_helper.php
+++ b/fuel/modules/fuel/helpers/MY_html_helper.php
@@ -29,7 +29,6 @@
  * @link		http://docs.getfuelcms.com/helpers/my_html_helper
  */
 
-
 // --------------------------------------------------------------------
 
 if (!function_exists('tag'))

--- a/fuel/modules/fuel/helpers/MY_html_helper.php
+++ b/fuel/modules/fuel/helpers/MY_html_helper.php
@@ -37,9 +37,9 @@ if (!function_exists('tag'))
 	 * Wrap an string or array of values in opening and closing tag
 	 *
 	 * @access	public
-	 * @param 	string 	opening tag element
-	 * @param 	string 	closing tag element
-	 * @param 	mixed 	array of values to be enclosed by tags
+	 * @param	string	opening tag element
+	 * @param	string	closing tag element
+	 * @param	mixed	array of values to be enclosed by tags
 	 * @param	boolean	echo to the screen
 	 * @return	string
 	 */
@@ -74,10 +74,10 @@ if (!function_exists('quote'))
 	 * Wrap a string into an HTML blockquote with quotes and cite added
 	 *
 	 * @access	public
-	 * @param 	string 	string to be enclosed by quote elements
-	 * @param 	string 	string source value
-	 * @param 	string 	string company/position value
-	 * @param 	string 	string css class
+	 * @param	string	string to be enclosed by quote elements
+	 * @param	string	string source value
+	 * @param	string	string company/position value
+	 * @param	string	string css class
 	 * @return	string
 	 */
 	function quote($quote, $cite = NULL, $title = NULL, $class = 'quote')
@@ -114,7 +114,7 @@ if (!function_exists('html_attrs'))
 	 * Create HTML attributes
 	 *
 	 * @access	public
-	 * @param 	mixed 	HTML attributs
+	 * @param	mixed	HTML attributs
 	 * @return	string
 	 */
 	function html_attrs($attrs)

--- a/fuel/modules/fuel/helpers/MY_language_helper.php
+++ b/fuel/modules/fuel/helpers/MY_language_helper.php
@@ -32,16 +32,16 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Get translated local strings with arguments. 
- * Overwrites CI langauge_helper to have a more useful args
- *
- * @param 	string
- * @param 	mixed
- * @return	string
- */
 if (!function_exists('lang'))
 {
+	/**
+	 * Get translated local strings with arguments.
+	 * Overwrites CI langauge_helper to have a more useful args
+	 *
+	 * @param 	string
+	 * @param 	mixed
+	 * @return	string
+	 */
 	function lang($key, $args = NULL)
 	{
 
@@ -69,15 +69,15 @@ if (!function_exists('lang'))
 
 // --------------------------------------------------------------------
 
-/**
- * Creates an array or JSON aobject for your javascript files that need localization
- *
- * @param 	array
- * @param 	boolean
- * @return	string
- */
 if (!function_exists('json_lang'))
 {
+	/**
+	 * Creates an array or JSON aobject for your javascript files that need localization
+	 *
+	 * @param 	array
+	 * @param 	boolean
+	 * @return	string
+	 */
 	function json_lang($js_localized = array(), $return_json = TRUE)
 	{
 		
@@ -131,14 +131,14 @@ if (!function_exists('json_lang'))
 
 // --------------------------------------------------------------------
 
-/**
- * Detects any specified language settings pulling from the URI, query string and then the user's browser settings
- *
- * @param 	boolean	Determines whether to set the "langauge" config property
- * @return	string
- */
 if (!function_exists('detect_lang'))
 {
+	/**
+	 * Detects any specified language settings pulling from the URI, query string and then the user's browser settings
+	 *
+	 * @param 	boolean	Determines whether to set the "langauge" config property
+	 * @return	string
+	 */
 	function detect_lang($set_config = FALSE)
 	{
 		$CI =& get_instance();

--- a/fuel/modules/fuel/helpers/MY_language_helper.php
+++ b/fuel/modules/fuel/helpers/MY_language_helper.php
@@ -29,7 +29,6 @@
  * @link		http://docs.getfuelcms.com/helpers/my_language_helper
  */
 
-
 // --------------------------------------------------------------------
 
 if (!function_exists('lang'))

--- a/fuel/modules/fuel/helpers/MY_language_helper.php
+++ b/fuel/modules/fuel/helpers/MY_language_helper.php
@@ -37,8 +37,8 @@ if (!function_exists('lang'))
 	 * Get translated local strings with arguments.
 	 * Overwrites CI langauge_helper to have a more useful args
 	 *
-	 * @param 	string
-	 * @param 	mixed
+	 * @param	string
+	 * @param	mixed
 	 * @return	string
 	 */
 	function lang($key, $args = NULL)
@@ -73,8 +73,8 @@ if (!function_exists('json_lang'))
 	/**
 	 * Creates an array or JSON aobject for your javascript files that need localization
 	 *
-	 * @param 	array
-	 * @param 	boolean
+	 * @param	array
+	 * @param	boolean
 	 * @return	string
 	 */
 	function json_lang($js_localized = array(), $return_json = TRUE)
@@ -135,7 +135,7 @@ if (!function_exists('detect_lang'))
 	/**
 	 * Detects any specified language settings pulling from the URI, query string and then the user's browser settings
 	 *
-	 * @param 	boolean	Determines whether to set the "langauge" config property
+	 * @param	boolean	Determines whether to set the "langauge" config property
 	 * @return	string
 	 */
 	function detect_lang($set_config = FALSE)

--- a/fuel/modules/fuel/helpers/MY_string_helper.php
+++ b/fuel/modules/fuel/helpers/MY_string_helper.php
@@ -32,15 +32,15 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Evaluates a strings PHP code. Used especially for outputing FUEL page data
- *
- * @param 	string 	string to evaluate
- * @param 	mixed 	variables to pass to the string
- * @return	string
- */
 if (!function_exists('eval_string'))
 {
+	/**
+	 * Evaluates a strings PHP code. Used especially for outputing FUEL page data
+	 *
+	 * @param 	string 	string to evaluate
+	 * @param 	mixed 	variables to pass to the string
+	 * @return	string
+	 */
 	function eval_string($str, $vars = array())
 	{
 		$CI =& get_instance();
@@ -69,17 +69,16 @@ if (!function_exists('eval_string'))
 
 // --------------------------------------------------------------------
 
-/**
- * Add an s to the end of s string based on the number 
- *
- * @param 	int 	number to compare against to determine if it needs to be plural
- * @param 	string 	string to evaluate
- * @param 	string 	plural value to add
- * @return	string
- */
-//
 if (!function_exists('pluralize'))
-{ 
+{
+	/**
+	 * Add an s to the end of s string based on the number
+	 *
+	 * @param 	int 	number to compare against to determine if it needs to be plural
+	 * @param 	string 	string to evaluate
+	 * @param 	string 	plural value to add
+	 * @return	string
+	 */
 	function pluralize($num, $str = '', $plural = 's')
 	{
 		if (is_array($num))
@@ -97,14 +96,14 @@ if (!function_exists('pluralize'))
 
 // --------------------------------------------------------------------
 
-/**
- * Strips extra whitespace from a string
- *
- * @param 	string
- * @return	string
- */
 if (!function_exists('strip_whitespace'))
 {
+	/**
+	 * Strips extra whitespace from a string
+	 *
+	 * @param 	string
+	 * @return	string
+	 */
 	function strip_whitespace($str)
 	{
 		return trim(preg_replace('/\s\s+|\n/m', '', $str));
@@ -113,14 +112,14 @@ if (!function_exists('strip_whitespace'))
 
 // --------------------------------------------------------------------
 
-/**
- * Trims extra whitespace from the end and beginning of a string on multiple lines
- *
- * @param 	string
- * @return	string
- */
 if (!function_exists('trim_multiline'))
 {
+	/**
+	 * Trims extra whitespace from the end and beginning of a string on multiple lines
+	 *
+	 * @param 	string
+	 * @return	string
+	 */
 	function trim_multiline($str)
 	{
 		return trim(implode("\n", array_map('trim', explode("\n", $str))));
@@ -129,15 +128,15 @@ if (!function_exists('trim_multiline'))
 
 // --------------------------------------------------------------------
 
-/**
- * Converts words to title case and allows for exceptions
- *
- * @param 	string 	string to evaluate
- * @param 	mixed 	variables to pass to the string
- * @return	string
- */
 if (!function_exists('smart_ucwords'))
 {
+	/**
+	 * Converts words to title case and allows for exceptions
+	 *
+	 * @param 	string 	string to evaluate
+	 * @param 	mixed 	variables to pass to the string
+	 * @return	string
+	 */
 	function smart_ucwords($str, $exceptions = array('of', 'the'))
 	{
 		$out = "";
@@ -153,17 +152,17 @@ if (!function_exists('smart_ucwords'))
 
 // --------------------------------------------------------------------
 
-/**
- * Removes "Gremlin" characters 
- *
- * (hidden control characters that the remove_invisible_characters function misses)
- *
- * @param 	string 	string to evaluate
- * @param 	string 	the value used to replace a gremlin
- * @return	string
- */
 if (!function_exists('zap_gremlins'))
 {
+	/**
+	 * Removes "Gremlin" characters
+	 *
+	 * (hidden control characters that the remove_invisible_characters function misses)
+	 *
+	 * @param 	string 	string to evaluate
+	 * @param 	string 	the value used to replace a gremlin
+	 * @return	string
+	 */
 	function zap_gremlins($str, $replace = '')
 	{
 		// there is a hidden bullet looking thingy that photoshop likes to include in it's text'
@@ -175,14 +174,14 @@ if (!function_exists('zap_gremlins'))
 
 // --------------------------------------------------------------------
 
-/**
- * Removes javascript from a string
- *
- * @param 	string 	string to remove javascript
- * @return	string
- */
 if (!function_exists('strip_javascript'))
 {
+	/**
+	 * Removes javascript from a string
+	 *
+	 * @param 	string 	string to remove javascript
+	 * @return	string
+	 */
 	function strip_javascript($str)
 	{
 		$str = preg_replace('#<script[^>]*>.*?</script>#is', '', $str);
@@ -192,15 +191,15 @@ if (!function_exists('strip_javascript'))
 
 // --------------------------------------------------------------------
 
-/**
- * Safely converts a string's entities without encoding HTML tags and quotes
- *
- * @param 	string 	string to evaluate
- * @param 	boolean determines whether to encode the ampersand or not
- * @return	string
- */
 if (!function_exists('safe_htmlentities'))
 {
+	/**
+	 * Safely converts a string's entities without encoding HTML tags and quotes
+	 *
+	 * @param 	string 	string to evaluate
+	 * @param 	boolean determines whether to encode the ampersand or not
+	 * @return	string
+	 */
 	function safe_htmlentities($str, $protect_amp = TRUE)
 	{
 		// convert all hex single quotes to numeric ... 

--- a/fuel/modules/fuel/helpers/MY_string_helper.php
+++ b/fuel/modules/fuel/helpers/MY_string_helper.php
@@ -37,8 +37,8 @@ if (!function_exists('eval_string'))
 	/**
 	 * Evaluates a strings PHP code. Used especially for outputing FUEL page data
 	 *
-	 * @param 	string 	string to evaluate
-	 * @param 	mixed 	variables to pass to the string
+	 * @param	string	string to evaluate
+	 * @param	mixed	variables to pass to the string
 	 * @return	string
 	 */
 	function eval_string($str, $vars = array())
@@ -74,9 +74,9 @@ if (!function_exists('pluralize'))
 	/**
 	 * Add an s to the end of s string based on the number
 	 *
-	 * @param 	int 	number to compare against to determine if it needs to be plural
-	 * @param 	string 	string to evaluate
-	 * @param 	string 	plural value to add
+	 * @param	int		number to compare against to determine if it needs to be plural
+	 * @param	string	string to evaluate
+	 * @param	string	plural value to add
 	 * @return	string
 	 */
 	function pluralize($num, $str = '', $plural = 's')
@@ -101,7 +101,7 @@ if (!function_exists('strip_whitespace'))
 	/**
 	 * Strips extra whitespace from a string
 	 *
-	 * @param 	string
+	 * @param	string
 	 * @return	string
 	 */
 	function strip_whitespace($str)
@@ -117,7 +117,7 @@ if (!function_exists('trim_multiline'))
 	/**
 	 * Trims extra whitespace from the end and beginning of a string on multiple lines
 	 *
-	 * @param 	string
+	 * @param	string
 	 * @return	string
 	 */
 	function trim_multiline($str)
@@ -133,8 +133,8 @@ if (!function_exists('smart_ucwords'))
 	/**
 	 * Converts words to title case and allows for exceptions
 	 *
-	 * @param 	string 	string to evaluate
-	 * @param 	mixed 	variables to pass to the string
+	 * @param	string	string to evaluate
+	 * @param	mixed	variables to pass to the string
 	 * @return	string
 	 */
 	function smart_ucwords($str, $exceptions = array('of', 'the'))
@@ -159,8 +159,8 @@ if (!function_exists('zap_gremlins'))
 	 *
 	 * (hidden control characters that the remove_invisible_characters function misses)
 	 *
-	 * @param 	string 	string to evaluate
-	 * @param 	string 	the value used to replace a gremlin
+	 * @param	string	string to evaluate
+	 * @param	string	the value used to replace a gremlin
 	 * @return	string
 	 */
 	function zap_gremlins($str, $replace = '')
@@ -179,7 +179,7 @@ if (!function_exists('strip_javascript'))
 	/**
 	 * Removes javascript from a string
 	 *
-	 * @param 	string 	string to remove javascript
+	 * @param	string	string to remove javascript
 	 * @return	string
 	 */
 	function strip_javascript($str)
@@ -196,8 +196,8 @@ if (!function_exists('safe_htmlentities'))
 	/**
 	 * Safely converts a string's entities without encoding HTML tags and quotes
 	 *
-	 * @param 	string 	string to evaluate
-	 * @param 	boolean determines whether to encode the ampersand or not
+	 * @param	string	string to evaluate
+	 * @param	boolean	determines whether to encode the ampersand or not
 	 * @return	string
 	 */
 	function safe_htmlentities($str, $protect_amp = TRUE)
@@ -247,8 +247,8 @@ if (!function_exists('safe_htmlentities'))
 /**
  * Convert PHP syntax to templating syntax
  *
- * @param 	string 	string to evaluate
- * @param   string  the templating engine to use
+ * @param	string	string to evaluate
+ * @param	string	the templating engine to use
  * @return	string
  */
 function php_to_template_syntax($str, $engine = NULL)
@@ -265,10 +265,10 @@ function php_to_template_syntax($str, $engine = NULL)
 /**
  * Convert string to  templating syntax
  *
- * @param 	string 	string to evaluate
- * @param 	array 	variables to parse with string
- * @param 	string	the templating engine to use
- * @param 	array 	an array of configuration variables like compile_dir, delimiters, allowed_functions, refs and data
+ * @param	string	string to evaluate
+ * @param	array	variables to parse with string
+ * @param	string	the templating engine to use
+ * @param	array	an array of configuration variables like compile_dir, delimiters, allowed_functions, refs and data
  * @return	string
  */
 function parse_template_syntax($str, $vars = array(), $engine = NULL, $config = array())

--- a/fuel/modules/fuel/helpers/MY_string_helper.php
+++ b/fuel/modules/fuel/helpers/MY_string_helper.php
@@ -248,6 +248,7 @@ if (!function_exists('safe_htmlentities'))
  * Convert PHP syntax to templating syntax
  *
  * @param 	string 	string to evaluate
+ * @param   string  the templating engine to use
  * @return	string
  */
 function php_to_template_syntax($str, $engine = NULL)

--- a/fuel/modules/fuel/helpers/MY_url_helper.php
+++ b/fuel/modules/fuel/helpers/MY_url_helper.php
@@ -129,7 +129,7 @@ if (!function_exists('uri_path'))
 	 *
 	 * @access	public
 	 * @param	boolean	use the rerouted URI string?
-	 * @param	boolean	the start index to build the uri path
+	 * @param	int	    the start index to build the uri path
 	 * @param	boolean	determines whether to strip any language segments
 	 * @return	string
 	 */
@@ -222,6 +222,7 @@ if (!function_exists('is_home'))
 	 * Determines if the page is the homepage or not
 	 *
 	 * @access	public
+	 * @param   string
 	 * @return	boolean
 	 */
 	function is_home($uri_path = NULL)
@@ -380,7 +381,7 @@ if (!function_exists('redirect'))
 	 * @access	public
 	 * @param	string	the URL
 	 * @param	string	the method: location or redirect
-	 * @param	string	the http response code
+	 * @param	int		the http response code
 	 * @param	string	wether to force or not https
 	 * @param	boolean	wether add the language to the URI
 	 * @return	string

--- a/fuel/modules/fuel/helpers/MY_url_helper.php
+++ b/fuel/modules/fuel/helpers/MY_url_helper.php
@@ -129,7 +129,7 @@ if (!function_exists('uri_path'))
 	 *
 	 * @access	public
 	 * @param	boolean	use the rerouted URI string?
-	 * @param	int	    the start index to build the uri path
+	 * @param	int		the start index to build the uri path
 	 * @param	boolean	determines whether to strip any language segments
 	 * @return	string
 	 */
@@ -168,7 +168,7 @@ if (!function_exists('uri_segment'))
 	 * Returns the uri segment
 	 *
 	 * @access	public
-	 * @param	int	the segment number
+	 * @param	int		the segment number
 	 * @param	string	the default value if the segment doesn't exist
 	 * @param	boolean	whether to use the rerouted uri
 	 * @param	boolean	determines whether to strip any language segments
@@ -222,7 +222,7 @@ if (!function_exists('is_home'))
 	 * Determines if the page is the homepage or not
 	 *
 	 * @access	public
-	 * @param   string
+	 * @param	string
 	 * @return	boolean
 	 */
 	function is_home($uri_path = NULL)
@@ -382,8 +382,8 @@ if (!function_exists('redirect'))
 	 * @param	string	the URL
 	 * @param	string	the method: location or redirect
 	 * @param	int		the http response code
-	 * @param	string	wether to force or not https
-	 * @param	boolean	wether add the language to the URI
+	 * @param	string	whether to force or not https
+	 * @param	boolean	whether add the language to the URI
 	 * @return	string
 	 */
 	function redirect($uri = '', $method = 'location', $http_response_code = 302, $https = NULL,  $language = FALSE)

--- a/fuel/modules/fuel/helpers/MY_url_helper.php
+++ b/fuel/modules/fuel/helpers/MY_url_helper.php
@@ -30,18 +30,18 @@
 
 // --------------------------------------------------------------------
 
-/**
- * This is just an alias to the normal CI site_url function but was added mainly to prevent conflicts with other systems like Wordpress (yes... sometimes the two need to be integrated)
- * Added simple return if the url begins with http
- *
- * @access	public
- * @param	string	the URI string
- * @param	boolean	sets or removes "https" from the URL. Must be set to TRUE or FALSE for it to explicitly work
- * @param	boolean	sets the language parameter on the URL based on the "language_mode" setting in the FUEL configuration
- * @return	string
- */
 if (!function_exists('url_to'))
 {
+	/**
+	 * This is just an alias to the normal CI site_url function but was added mainly to prevent conflicts with other systems like Wordpress (yes... sometimes the two need to be integrated)
+	 * Added simple return if the url begins with http
+	 *
+	 * @access	public
+	 * @param	string	the URI string
+	 * @param	boolean	sets or removes "https" from the URL. Must be set to TRUE or FALSE for it to explicitly work
+	 * @param	boolean	sets the language parameter on the URL based on the "language_mode" setting in the FUEL configuration
+	 * @return	string
+	 */
 	function url_to($uri = '', $https = NULL, $language = NULL)
 	{
 		if (is_http_path($uri)) return $uri;
@@ -77,17 +77,17 @@ if (!function_exists('url_to'))
 
 // --------------------------------------------------------------------
 
-/**
- * Site URL which is an alias to the url_to function
- *
- * @access	public
- * @param	string	the URI string
- * @param	boolean	sets or removes "https" from the URL. Must be set to TRUE or FALSE for it to explicitly work
- * @param	boolean	sets the language parameter on the URL based on the "language_mode" setting in the FUEL configuration
- * @return	string
- */
 if (!function_exists('site_url'))
 {
+	/**
+	 * Site URL which is an alias to the url_to function
+	 *
+	 * @access	public
+	 * @param	string	the URI string
+	 * @param	boolean	sets or removes "https" from the URL. Must be set to TRUE or FALSE for it to explicitly work
+	 * @param	boolean	sets the language parameter on the URL based on the "language_mode" setting in the FUEL configuration
+	 * @return	string
+	 */
 	function site_url($uri = '', $https = NULL, $language = NULL)
 	{
 		return url_to($uri, $https, $language);
@@ -96,17 +96,17 @@ if (!function_exists('site_url'))
 
 // --------------------------------------------------------------------
 
-/**
- * Current URL
- * Added show_query_str parameter
- *
- * @access	public
- * @param	boolean	determines whether to include query string parameters
- * @param	boolean	determines whether to change the language value
- * @return	string
- */
 if (!function_exists('current_url'))
 {
+	/**
+	 * Current URL
+	 * Added show_query_str parameter
+	 *
+	 * @access	public
+	 * @param	boolean	determines whether to include query string parameters
+	 * @param	boolean	determines whether to change the language value
+	 * @return	string
+	 */
 	function current_url($show_query_str = FALSE, $lang = NULL)
 	{
 		$CI =& get_instance();
@@ -122,17 +122,17 @@ if (!function_exists('current_url'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns the uri path normalized
- *
- * @access	public
- * @param	boolean	use the rerouted URI string?
- * @param	boolean	the start index to build the uri path
- * @param	boolean	determines whether to strip any language segments
- * @return	string
- */
 if (!function_exists('uri_path'))
 {
+	/**
+	 * Returns the uri path normalized
+	 *
+	 * @access	public
+	 * @param	boolean	use the rerouted URI string?
+	 * @param	boolean	the start index to build the uri path
+	 * @param	boolean	determines whether to strip any language segments
+	 * @return	string
+	 */
 	function uri_path($rerouted = TRUE, $start_index = 0, $strip_lang = TRUE)
 	{
 		$CI =& get_instance();
@@ -162,18 +162,18 @@ if (!function_exists('uri_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns the uri segment
- *
- * @access	public
- * @param	int	the segment number
- * @param	string	the default value if the segment doesn't exist
- * @param	boolean	whether to use the rerouted uri
- * @param	boolean	determines whether to strip any language segments
- * @return	string
- */
 if (!function_exists('uri_segment'))
 {
+	/**
+	 * Returns the uri segment
+	 *
+	 * @access	public
+	 * @param	int	the segment number
+	 * @param	string	the default value if the segment doesn't exist
+	 * @param	boolean	whether to use the rerouted uri
+	 * @param	boolean	determines whether to strip any language segments
+	 * @return	string
+	 */
 	function uri_segment($n, $default = FALSE, $rerouted = TRUE, $strip_lang = TRUE)
 	{
 		$CI =& get_instance();
@@ -199,15 +199,15 @@ if (!function_exists('uri_segment'))
 
 // --------------------------------------------------------------------
 
-/**
- * Helper function to determine if it is a local path
- *
- * @access	public
- * @param	string	URL
- * @return	string
- */
 if (!function_exists('is_http_path'))
 {
+	/**
+	 * Helper function to determine if it is a local path
+	 *
+	 * @access	public
+	 * @param	string	URL
+	 * @return	string
+	 */
 	function is_http_path($path)
 	{
 		return (preg_match('!^\w+://! i', $path));
@@ -216,14 +216,14 @@ if (!function_exists('is_http_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Determines if the page is the homepage or not
- *
- * @access	public
- * @return	boolean
- */
 if (!function_exists('is_home'))
 {
+	/**
+	 * Determines if the page is the homepage or not
+	 *
+	 * @access	public
+	 * @return	boolean
+	 */
 	function is_home($uri_path = NULL)
 	{
 		if (is_null($uri_path))
@@ -239,14 +239,14 @@ if (!function_exists('is_home'))
 
 // --------------------------------------------------------------------
 
-/**
- * Determines if the page is 404
- *
- * @access	public
- * @return	boolean
- */
 if (!function_exists('is_404'))
 {
+	/**
+	 * Determines if the page is 404
+	 *
+	 * @access	public
+	 * @return	boolean
+	 */
 	function is_404()
 	{
 		return (http_response_code() == 404);
@@ -255,16 +255,16 @@ if (!function_exists('is_404'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns the last page you visited
- *
- * @access	public
- * @param	string	Default value if no last page exists
- * @param	boolean	Whether to return only the URI part of the the URL
- * @return	boolean
- */
 if (!function_exists('last_url'))
 {
+	/**
+	 * Returns the last page you visited
+	 *
+	 * @access	public
+	 * @param	string	Default value if no last page exists
+	 * @param	boolean	Whether to return only the URI part of the the URL
+	 * @return	boolean
+	 */
 	function last_url($default = FALSE, $only_uri = FALSE)
 	{
 		$back_url = (isset($_SERVER['HTTP_REFERER']) AND $_SERVER['HTTP_REFERER'] != current_url()) ? $_SERVER['HTTP_REFERER'] : $default;
@@ -291,16 +291,16 @@ if (!function_exists('last_url'))
 
 // --------------------------------------------------------------------
 
-/**
- * Will return a target="_blank" if the link is not from the same domain.
- *
- * @access	public
- * @param	string	URL
- * @param	array	An array of extensions to check to force it to target="_blank"
- * @return	boolean
- */
 if (!function_exists('link_target'))
 {
+	/**
+	 * Will return a target="_blank" if the link is not from the same domain.
+	 *
+	 * @access	public
+	 * @param	string	URL
+	 * @param	array	An array of extensions to check to force it to target="_blank"
+	 * @return	boolean
+	 */
 	function link_target($link, $exts = array())
 	{
 		$url_parts = parse_url($link);
@@ -350,15 +350,15 @@ if (!function_exists('link_target'))
 
 // --------------------------------------------------------------------
 
-/**
- * Checks the redirects before showing a 404
- *
- * @access	public
- * @param	boolean	Whether to redirect or not
- * @return	void
- */
 if (!function_exists('redirect_404'))
 {
+	/**
+	 * Checks the redirects before showing a 404
+	 *
+	 * @access	public
+	 * @param	boolean	Whether to redirect or not
+	 * @return	void
+	 */
 	function redirect_404($redirect = TRUE)
 	{
 		$CI =& get_instance();
@@ -368,23 +368,23 @@ if (!function_exists('redirect_404'))
 
 // ------------------------------------------------------------------------
 
-/**
- * Header Redirect (Overwritten to account for adding HTTPS and adding language path in site_url function)
- *
- * Header redirect in two flavors
- * For very fine grained control over headers, you could use the Output
- * Library's set_header() function.
- *
- * @access	public
- * @param	string	the URL
- * @param	string	the method: location or redirect
- * @param	string	the http response code
- * @param	string	wether to force or not https
- * @param	boolean	wether add the language to the URI
- * @return	string
- */
 if (!function_exists('redirect'))
 {
+	/**
+	 * Header Redirect (Overwritten to account for adding HTTPS and adding language path in site_url function)
+	 *
+	 * Header redirect in two flavors
+	 * For very fine grained control over headers, you could use the Output
+	 * Library's set_header() function.
+	 *
+	 * @access	public
+	 * @param	string	the URL
+	 * @param	string	the method: location or redirect
+	 * @param	string	the http response code
+	 * @param	string	wether to force or not https
+	 * @param	boolean	wether add the language to the URI
+	 * @return	string
+	 */
 	function redirect($uri = '', $method = 'location', $http_response_code = 302, $https = NULL,  $language = FALSE)
 	{
 		if ( ! preg_match('#^https?://#i', $uri))
@@ -408,17 +408,17 @@ if (!function_exists('redirect'))
 }
 // ------------------------------------------------------------------------
 
-/**
- * Returns whether the current page is using SSL (https)
- *
- * @access	public
- * @param	string	the URL
- * @param	string	the method: location or redirect
- * @return	string
- */
 // used function exists to future proof it https://github.com/IT-Can/CodeIgniter/commit/98bc5d985b7119ff71b9f50a1b226559f647797a
 if ( ! function_exists('is_https'))
 {
+	/**
+	 * Returns whether the current page is using SSL (https)
+	 *
+	 * @access	public
+	 * @param	string	the URL
+	 * @param	string	the method: location or redirect
+	 * @return	string
+	 */
 	function is_https()
 	{
 		return ((!empty($_SERVER['HTTPS']) AND strtolower($_SERVER['HTTPS']) !== 'off'));
@@ -427,17 +427,17 @@ if ( ! function_exists('is_https'))
 
 // ------------------------------------------------------------------------
 
-/**
- * Returns a query string formatted
- *
- * @access	public
- * @param	array	an array of query string parameters to exclude
- * @param	boolean	determines whether to include posted variables in the query string
- * @param	boolean	determines whether to include the question mark
- * @return	string
- */
 if (!function_exists('query_str'))
 {
+	/**
+	 * Returns a query string formatted
+	 *
+	 * @access	public
+	 * @param	array	an array of query string parameters to exclude
+	 * @param	boolean	determines whether to include posted variables in the query string
+	 * @param	boolean	determines whether to include the question mark
+	 * @return	string
+	 */
 	function query_str($exclude = array(), $include_post = FALSE, $include_q = TRUE)
 	{
 		$CI =& get_instance();

--- a/fuel/modules/fuel/helpers/ajax_helper.php
+++ b/fuel/modules/fuel/helpers/ajax_helper.php
@@ -3,7 +3,7 @@
  * FUEL CMS
  * http://www.getfuelcms.com
  *
- * An open source Content Management System based on the 
+ * An open source Content Management System based on the
  * Codeigniter framework (http://codeigniter.com)
  *
  * @package		FUEL CMS
@@ -31,14 +31,14 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a boolean value based on whether the page was requested via AJAX or not
- *
- * @access	public
- * @return	boolean
- */	
 if (!function_exists('is_ajax'))
 {
+	/**
+	 * Returns a boolean value based on whether the page was requested via AJAX or not
+	 *
+	 * @access	public
+	 * @return	boolean
+	 */
 	function is_ajax()
 	{
 		return (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH']=="XMLHttpRequest");
@@ -47,15 +47,15 @@ if (!function_exists('is_ajax'))
 
 // --------------------------------------------------------------------
 
-/**
- * Sets the HTTP headers for 
- *
- * @access	public
- * @param	boolean	Sets the no cache headers
- * @return	boolean
- */	
 if (!function_exists('json_headers'))
 {
+	/**
+	 * Sets the HTTP headers for
+	 *
+	 * @access	public
+	 * @param	boolean	Sets the no cache headers
+	 * @return	void
+	 */
 	function json_headers($no_cache = TRUE)
 	{
 		if ($no_cache)

--- a/fuel/modules/fuel/helpers/asset_helper.php
+++ b/fuel/modules/fuel/helpers/asset_helper.php
@@ -3,7 +3,7 @@
  * FUEL CMS
  * http://www.getfuelcms.com
  *
- * An open source Content Management System based on the 
+ * An open source Content Management System based on the
  * Codeigniter framework (http://codeigniter.com)
  *
  * @package		FUEL CMS
@@ -19,8 +19,8 @@
 /**
  * FUEL Asset Helper
  *
- * This helper allows you to output css, js links and/or files as well as 
- * allows you to compress and cache them. Also has convenience methods for 
+ * This helper allows you to output css, js links and/or files as well as
+ * allows you to compress and cache them. Also has convenience methods for
  * paths to assets. It is essentially an alias to the Asset Class.
  *
  * @package		FUEL CMS
@@ -258,9 +258,10 @@ if (!function_exists('assets_server_to_web_path'))
 	/**
 	 * Convert a server path to a web path
 	 *
-	 * @access	public
-	 * @param	string	server path to asset file
-	 * @return	string
+	 * @access  public
+	 * @param   string  server path to asset file
+	 * @param   bool    truncate to asset folder
+	 * @return  string
 	 */
 	function assets_server_to_web_path($file, $truncate_to_asset_folder = FALSE)
 	{
@@ -378,8 +379,10 @@ if (!function_exists('swf'))
 	 *
 	 * @access	public
 	 * @param	string	file name of the swf file including extension
-	 * @param	string	module module folder if any
-	 * @param	array	additional parameter to include (attrs, ie_conditional, and output)
+	 * @param	string	html id that the flash will replace with swfobject
+	 * @param	int		width of the flash file
+	 * @param	int		height of the flash file
+	 * @param	array	additional parameter to include (vars, version, and color, params)
 	 * @return	string
 	 */
 	function swf($flash, $id, $width, $height, $options = array()){

--- a/fuel/modules/fuel/helpers/asset_helper.php
+++ b/fuel/modules/fuel/helpers/asset_helper.php
@@ -30,7 +30,6 @@
  * @link		http://docs.getfuelcms.com/helpers/asset_helper
  */
 
-
 // --------------------------------------------------------------------
 
 if (!function_exists('img_path'))

--- a/fuel/modules/fuel/helpers/asset_helper.php
+++ b/fuel/modules/fuel/helpers/asset_helper.php
@@ -258,10 +258,10 @@ if (!function_exists('assets_server_to_web_path'))
 	/**
 	 * Convert a server path to a web path
 	 *
-	 * @access  public
-	 * @param   string  server path to asset file
-	 * @param   bool    truncate to asset folder
-	 * @return  string
+	 * @access	public
+	 * @param	string	server path to asset file
+	 * @param	bool	truncate to asset folder
+	 * @return	string
 	 */
 	function assets_server_to_web_path($file, $truncate_to_asset_folder = FALSE)
 	{

--- a/fuel/modules/fuel/helpers/asset_helper.php
+++ b/fuel/modules/fuel/helpers/asset_helper.php
@@ -33,17 +33,17 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Returns an image asset path
- *
- * @access	public
- * @param	string	image file name including extension
- * @param	string	module folder if any
- * @param	boolean	whether to include http://... at beginning
- * @return	string
- */	
 if (!function_exists('img_path'))
 {
+	/**
+	 * Returns an image asset path
+	 *
+	 * @access	public
+	 * @param	string	image file name including extension
+	 * @param	string	module folder if any
+	 * @param	boolean	whether to include http://... at beginning
+	 * @return	string
+	 */
 	function img_path($file = NULL, $module = NULL, $absolute = NULL)
 	{
 		$CI = _get_assets();
@@ -53,17 +53,17 @@ if (!function_exists('img_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a css asset path
- *
- * @access	public
- * @param	string	css file name (extension not required)
- * @param	string	module folder if any
- * @param	boolean	whether to include http://... at beginning
- * @return	string
- */	
 if (!function_exists('css_path'))
 {
+	/**
+	 * Returns a css asset path
+	 *
+	 * @access	public
+	 * @param	string	css file name (extension not required)
+	 * @param	string	module folder if any
+	 * @param	boolean	whether to include http://... at beginning
+	 * @return	string
+	 */
 	function css_path($file = NULL, $module = NULL, $absolute = NULL)
 	{
 		$CI = _get_assets();
@@ -73,17 +73,17 @@ if (!function_exists('css_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a js asset path
- *
- * @access	public
- * @param	string	javascript file name (extension not required)
- * @param	string	module folder if any
- * @param	boolean	whether to include http://... at beginning
- * @return	string
- */	
 if (!function_exists('js_path'))
 {
+	/**
+	 * Returns a js asset path
+	 *
+	 * @access	public
+	 * @param	string	javascript file name (extension not required)
+	 * @param	string	module folder if any
+	 * @param	boolean	whether to include http://... at beginning
+	 * @return	string
+	 */
 	function js_path($file = NULL, $module = NULL, $absolute = NULL)
 	{
 		$CI = _get_assets();
@@ -93,17 +93,17 @@ if (!function_exists('js_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a swf asset path
- *
- * @access	public
- * @param	string	swf file name (extension not required)
- * @param	string	module folder if any
- * @param	boolean	whether to include http://... at beginning
- * @return	string
- */	
 if (!function_exists('swf_path'))
 {
+	/**
+	 * Returns a swf asset path
+	 *
+	 * @access	public
+	 * @param	string	swf file name (extension not required)
+	 * @param	string	module folder if any
+	 * @param	boolean	whether to include http://... at beginning
+	 * @return	string
+	 */
 	function swf_path($file = NULL, $module = NULL, $absolute = NULL)
 	{
 		$CI = _get_assets();
@@ -113,17 +113,17 @@ if (!function_exists('swf_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a pdf asset path
- *
- * @access	public
- * @param	string	pdf file name (extension not required)
- * @param	string	module folder if any
- * @param	boolean	whether to include http://... at beginning
- * @return	string
- */	
 if (!function_exists('pdf_path'))
 {
+	/**
+	 * Returns a pdf asset path
+	 *
+	 * @access	public
+	 * @param	string	pdf file name (extension not required)
+	 * @param	string	module folder if any
+	 * @param	boolean	whether to include http://... at beginning
+	 * @return	string
+	 */
 	function pdf_path($file = NULL, $module = NULL, $absolute = NULL)
 	{
 		$CI = _get_assets();
@@ -133,17 +133,17 @@ if (!function_exists('pdf_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a media asset path (e.g. quicktime .mov)
- *
- * @access	public
- * @param	string	pdf file name including extension
- * @param	string	module folder if any
- * @param	boolean	whether to include http://... at beginning
- * @return	string
- */	
 if (!function_exists('media_path'))
 {
+	/**
+	 * Returns a media asset path (e.g. quicktime .mov)
+	 *
+	 * @access	public
+	 * @param	string	pdf file name including extension
+	 * @param	string	module folder if any
+	 * @param	boolean	whether to include http://... at beginning
+	 * @return	string
+	 */
 	function media_path($file = NULL, $module = NULL, $absolute = NULL)
 	{
 		$CI = _get_assets();
@@ -153,17 +153,17 @@ if (!function_exists('media_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a document asset path (e.g. doc, docx)
- *
- * @access	public
- * @param	string	docs file name including extension
- * @param	string	module folder if any
- * @param	boolean	whether to include http://... at beginning
- * @return	string
- */	
 if (!function_exists('docs_path'))
 {
+	/**
+	 * Returns a document asset path (e.g. doc, docx)
+	 *
+	 * @access	public
+	 * @param	string	docs file name including extension
+	 * @param	string	module folder if any
+	 * @param	boolean	whether to include http://... at beginning
+	 * @return	string
+	 */
 	function docs_path($file = NULL, $module = NULL, $absolute = NULL)
 	{
 		$CI = _get_assets();
@@ -173,17 +173,17 @@ if (!function_exists('docs_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a cache asset path
- *
- * @access	public
- * @param	string	cached file name including extension
- * @param	string	module folder if any
- * @param	boolean	whether to include http://... at beginning
- * @return	string
- */	
 if (!function_exists('cache_path'))
 {
+	/**
+	 * Returns a cache asset path
+	 *
+	 * @access	public
+	 * @param	string	cached file name including extension
+	 * @param	string	module folder if any
+	 * @param	boolean	whether to include http://... at beginning
+	 * @return	string
+	 */
 	function cache_path($file = NULL, $module = NULL, $absolute = NULL)
 	{
 		$CI = _get_assets();
@@ -193,17 +193,17 @@ if (!function_exists('cache_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a captcha image path
- *
- * @access	public
- * @param	string	captcha file name including extension
- * @param	string	module folder if any
- * @param	boolean	whether to include http://... at beginning
- * @return	string
- */	
 if (!function_exists('captcha_path'))
 {
+	/**
+	 * Returns a captcha image path
+	 *
+	 * @access	public
+	 * @param	string	captcha file name including extension
+	 * @param	string	module folder if any
+	 * @param	boolean	whether to include http://... at beginning
+	 * @return	string
+	 */
 	function captcha_path($file = NULL, $module = NULL, $absolute = NULL)
 	{
 		$CI = _get_assets();
@@ -213,18 +213,18 @@ if (!function_exists('captcha_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns an asset path and is what the others above use
- *
- * @access	public
- * @param	string	asset file name including extension
- * @param	string	subfolder to asset file (e.g. images, js, css... etc)
- * @param	string	module folder if any
- * @param	boolean	whether to include http://... at beginning
- * @return	string
- */	
 if (!function_exists('assets_path'))
 {
+	/**
+	 * Returns an asset path and is what the others above use
+	 *
+	 * @access	public
+	 * @param	string	asset file name including extension
+	 * @param	string	subfolder to asset file (e.g. images, js, css... etc)
+	 * @param	string	module folder if any
+	 * @param	boolean	whether to include http://... at beginning
+	 * @return	string
+	 */
 	function assets_path($file = NULL, $path = NULL, $module = NULL,  $absolute = NULL)
 	{
 		$CI = _get_assets();
@@ -234,17 +234,17 @@ if (!function_exists('assets_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Get the server path
- *
- * @access	public
- * @param	string	asset file name including extension
- * @param	string	subfolder to asset file (e.g. images, js, css... etc)
- * @param	string	module folder if any
- * @return	string
- */	
 if (!function_exists('assets_server_path'))
 {
+	/**
+	 * Get the server path
+	 *
+	 * @access	public
+	 * @param	string	asset file name including extension
+	 * @param	string	subfolder to asset file (e.g. images, js, css... etc)
+	 * @param	string	module folder if any
+	 * @return	string
+	 */
 	function assets_server_path($file = NULL, $path = NULL, $module = NULL)
 	{
 		$CI = _get_assets();
@@ -254,15 +254,15 @@ if (!function_exists('assets_server_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Convert a server path to a web path
- *
- * @access	public
- * @param	string	server path to asset file
- * @return	string
- */	
 if (!function_exists('assets_server_to_web_path'))
 {
+	/**
+	 * Convert a server path to a web path
+	 *
+	 * @access	public
+	 * @param	string	server path to asset file
+	 * @return	string
+	 */
 	function assets_server_to_web_path($file, $truncate_to_asset_folder = FALSE)
 	{
 		$CI = _get_assets();
@@ -272,17 +272,17 @@ if (!function_exists('assets_server_to_web_path'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a boolean value of whether a file exists
- *
- * @access	public
- * @param	string	asset file name including extension
- * @param	string	subfolder to asset file (e.g. images, js, css... etc)
- * @param	string	module folder if any
- * @return	boolean
- */	
 if (!function_exists('asset_exists'))
 {
+	/**
+	 * Returns a boolean value of whether a file exists
+	 *
+	 * @access	public
+	 * @param	string	asset file name including extension
+	 * @param	string	subfolder to asset file (e.g. images, js, css... etc)
+	 * @param	string	module folder if any
+	 * @return	boolean
+	 */
 	function asset_exists($file = NULL, $path = NULL, $module = NULL)
 	{
 		$CI = _get_assets();
@@ -292,18 +292,18 @@ if (!function_exists('asset_exists'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns the file size of an asset
- *
- * @access	public
- * @param	string	asset file name including extension
- * @param	string	subfolder to asset file (e.g. images, js, css... etc)
- * @param	string	module folder if any
- * @param	boolean	format
- * @return	string
- */	
 if (!function_exists('asset_filesize'))
 {
+	/**
+	 * Returns the file size of an asset
+	 *
+	 * @access	public
+	 * @param	string	asset file name including extension
+	 * @param	string	subfolder to asset file (e.g. images, js, css... etc)
+	 * @param	string	module folder if any
+	 * @param	boolean	format
+	 * @return	string
+	 */
 	function asset_filesize($file = NULL, $path = NULL, $module = NULL, $format = FALSE)
 	{
 		$CI = _get_assets();
@@ -313,16 +313,16 @@ if (!function_exists('asset_filesize'))
 
 // --------------------------------------------------------------------
 
-/**
- * Creates javascript code that first tries to pull in jquery from the Google CDN, and if it doesn't exist, goes to the local backup version
- *
- * @access	public
- * @param	string	jQuery version number for Google CDN
- * @param	string	local asset path to default version
- * @return	string
- */	
 if (!function_exists('jquery'))
 {
+	/**
+	 * Creates javascript code that first tries to pull in jquery from the Google CDN, and if it doesn't exist, goes to the local backup version
+	 *
+	 * @access	public
+	 * @param	string	jQuery version number for Google CDN
+	 * @param	string	local asset path to default version
+	 * @return	string
+	 */
 	function jquery($version = '1.7.1', $default = 'jquery')
 	{
 		$CI = _get_assets();
@@ -332,17 +332,17 @@ if (!function_exists('jquery'))
 
 // --------------------------------------------------------------------
 
-/**
- * Inserts <script ...></script> tags based on configuration settings for js file path
- *
- * @access	public
- * @param	string	file name(s) of the JS files (.css extension is not needed). Can be an array or comma separated list.
- * @param	string	module module folder if any
- * @param	array	additional parameter to include (attrs, ie_conditional, and output)
- * @return	string
- */	
 if (!function_exists('js'))
 {
+	/**
+	 * Inserts <script ...></script> tags based on configuration settings for js file path
+	 *
+	 * @access	public
+	 * @param	string	file name(s) of the JS files (.css extension is not needed). Can be an array or comma separated list.
+	 * @param	string	module module folder if any
+	 * @param	array	additional parameter to include (attrs, ie_conditional, and output)
+	 * @return	string
+	 */
 	function js($path, $module = '', $options = array())
 	{
 		$CI = _get_assets();
@@ -352,17 +352,17 @@ if (!function_exists('js'))
 
 // --------------------------------------------------------------------
 
-/**
- * Inserts <link ... /> tags based on configuration settings for css file path
- *
- * @access	public
- * @param	string	file name(s) of the CSS files (.css extension is not needed). Can be an array or comma separated list.
- * @param	string	module module folder if any
- * @param	array	additional parameter to include (attrs, ie_conditional, and output)
- * @return	string
- */	
 if (!function_exists('css'))
 {
+	/**
+	 * Inserts <link ... /> tags based on configuration settings for css file path
+	 *
+	 * @access	public
+	 * @param	string	file name(s) of the CSS files (.css extension is not needed). Can be an array or comma separated list.
+	 * @param	string	module module folder if any
+	 * @param	array	additional parameter to include (attrs, ie_conditional, and output)
+	 * @return	string
+	 */
 	function css($path, $module = '', $options = array())
 	{
 		$CI = _get_assets();
@@ -372,17 +372,17 @@ if (!function_exists('css'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns an swf asset path
- *
- * @access	public
- * @param	string	file name of the swf file including extension
- * @param	string	module module folder if any
- * @param	array	additional parameter to include (attrs, ie_conditional, and output)
- * @return	string
- */	
 if (!function_exists('swf'))
 {
+	/**
+	 * Returns an swf asset path
+	 *
+	 * @access	public
+	 * @param	string	file name of the swf file including extension
+	 * @param	string	module module folder if any
+	 * @param	array	additional parameter to include (attrs, ie_conditional, and output)
+	 * @return	string
+	 */
 	function swf($flash, $id, $width, $height, $options = array()){
 		$CI = _get_assets();
 		return $CI->asset->swf($flash, $id, $width, $height, $options);
@@ -391,19 +391,19 @@ if (!function_exists('swf'))
 
 // --------------------------------------------------------------------
 
-/**
- * Uses the "http://placehold.it" service to display images (good for mocking up sites)
- *
- * @access	public
- * @param	int		width of placeholder image (optional)
- * @param	int		height of placeholder image (optional)
- * @param	string	text to display inside placeholder
- * @param	string	color of placeholder
- * @param	boolean	determines whether to wrap it in an image tag or just return the path (optional)
- * @return	string
- */	
 if (!function_exists('placeholder'))
 {
+	/**
+	 * Uses the "http://placehold.it" service to display images (good for mocking up sites)
+	 *
+	 * @access	public
+	 * @param	int		width of placeholder image (optional)
+	 * @param	int		height of placeholder image (optional)
+	 * @param	string	text to display inside placeholder
+	 * @param	string	color of placeholder
+	 * @param	boolean	determines whether to wrap it in an image tag or just return the path (optional)
+	 * @return	string
+	 */
 	function placeholder($width = 100, $height = '', $text = '', $colors = '', $img_tag = FALSE)
 	{
 		$dimentions = $width.( !empty($height) ? 'x'.$height : '');
@@ -426,7 +426,7 @@ if (!function_exists('placeholder'))
  *
  * @access	public
  * @return	CI super object
- */	
+ */
 function _get_assets()
 {
 	$CI =& get_instance();

--- a/fuel/modules/fuel/helpers/browser_helper.php
+++ b/fuel/modules/fuel/helpers/browser_helper.php
@@ -35,7 +35,7 @@ if (!function_exists('browser_info'))
 	 * Originally from: http://us3.php.net/function.get-browser
 	 *
 	 * @access	public
-	 * @param	string	browser agant (optional)
+	 * @param	string	browser agent (optional)
 	 * @return	array
 	 */
 	function browser_info($agent = NULL)

--- a/fuel/modules/fuel/helpers/browser_helper.php
+++ b/fuel/modules/fuel/helpers/browser_helper.php
@@ -26,7 +26,6 @@
  * @link		http://docs.getfuelcms.com/helpers/browser_helper
  */
 
-
 // --------------------------------------------------------------------
 
 if (!function_exists('browser_info'))
@@ -60,5 +59,6 @@ if (!function_exists('browser_info'))
 		return array($matches['browser'][$i] => $matches['version'][$i]);
 	}
 }
+
 /* End of file browser_helper.php */
 /* Location: ./modules/fuel/helpers/browser_helper.php */

--- a/fuel/modules/fuel/helpers/browser_helper.php
+++ b/fuel/modules/fuel/helpers/browser_helper.php
@@ -29,16 +29,16 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Returns an array of browser information
- * Originally from: http://us3.php.net/function.get-browser
- * 
- * @access	public
- * @param	string	browser agant (optional)
- * @return	array
- */	
 if (!function_exists('browser_info'))
 {
+	/**
+	 * Returns an array of browser information
+	 * Originally from: http://us3.php.net/function.get-browser
+	 *
+	 * @access	public
+	 * @param	string	browser agant (optional)
+	 * @return	array
+	 */
 	function browser_info($agent = NULL)
 	{
 	 	// Declare known browsers to look for

--- a/fuel/modules/fuel/helpers/compatibility_helper.php
+++ b/fuel/modules/fuel/helpers/compatibility_helper.php
@@ -27,7 +27,6 @@
  * @link		http://docs.getfuelcms.com/helpers/compatibility_helper
  */
 
-
 // --------------------------------------------------------------------
 
 if (!function_exists('json_encode'))

--- a/fuel/modules/fuel/helpers/compatibility_helper.php
+++ b/fuel/modules/fuel/helpers/compatibility_helper.php
@@ -30,17 +30,17 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Used for older versions of PHP that don't support json_encode.
- * another option http://derekallard.com/blog/post/using-json-on-servers-without-native-support/
- * Original function found here: http://php.net/manual/en/function.json-encode.php
- *
- * @access	public
- * @param	mixed	php value to encode into JSON format
- * @return	string
- */
 if (!function_exists('json_encode'))
 {
+	/**
+	 * Used for older versions of PHP that don't support json_encode.
+	 * another option http://derekallard.com/blog/post/using-json-on-servers-without-native-support/
+	 * Original function found here: http://php.net/manual/en/function.json-encode.php
+	 *
+	 * @access	public
+	 * @param	mixed	php value to encode into JSON format
+	 * @return	string
+	 */
 	function json_encode($a=FALSE)
 	{
 		if (is_null($a)) return 'null';
@@ -87,16 +87,17 @@ if (!function_exists('json_encode'))
 
 // --------------------------------------------------------------------
 
-/**
- * Used for older versions of PHP that don't support json_decode.
- * another option http://derekallard.com/blog/post/using-json-on-servers-without-native-support/
- * Original function found here: http://php.net/manual/en/function.json-decode.php
- *
- * @access	public
- * @param	string	json formatted string
- * @return	mixed
- */
-if ( !function_exists('json_decode')){ 
+if ( !function_exists('json_decode'))
+{
+	/**
+	 * Used for older versions of PHP that don't support json_decode.
+	 * another option http://derekallard.com/blog/post/using-json-on-servers-without-native-support/
+	 * Original function found here: http://php.net/manual/en/function.json-decode.php
+	 *
+	 * @access	public
+	 * @param	string	json formatted string
+	 * @return	mixed
+	 */
 	function json_decode($json) 
 	{  
 		// Author: walidator.info 2009 
@@ -140,19 +141,19 @@ if ( !function_exists('json_decode')){
 
 // ------------------------------------------------------------------------
 
-/**
- * Used for older versions of PHP that don't support str_getcsv.
- * Original function found here: http://php.net/manual/en/function.str-getcsv.php
- *
- * @access	public
- * @param	string
- * @param	string
- * @param	string
- * @param	string
- * @return	mixed
- */
 if (!function_exists('str_getcsv'))
-{ 
+{
+	/**
+	 * Used for older versions of PHP that don't support str_getcsv.
+	 * Original function found here: http://php.net/manual/en/function.str-getcsv.php
+	 *
+	 * @access	public
+	 * @param	string
+	 * @param	string
+	 * @param	string
+	 * @param	string
+	 * @return	mixed
+	 */
 	function str_getcsv($input, $delimiter = ",", $enclosure = '"', $escape = "\\")
 	{ 
 		$fiveMBs = 5 * 1024 * 1024; 
@@ -169,19 +170,19 @@ if (!function_exists('str_getcsv'))
 
 // --------------------------------------------------------------------
 
-/**
- * Not really a compatibility function since it doesn't exist natively in PHP.
- * However it probably should so we provide it here.
- * A version of the original function found here: http://glossword.googlecode.com/svn-history/r600/trunk/core/gw_includes/functions.php
- *
- * @access	public
- * @param	string
- * @param	string
- * @param	string
- * @return	mixed
- */
 if(!function_exists('str_putcsv'))
 {
+	/**
+	 * Not really a compatibility function since it doesn't exist natively in PHP.
+	 * However it probably should so we provide it here.
+	 * A version of the original function found here: http://glossword.googlecode.com/svn-history/r600/trunk/core/gw_includes/functions.php
+	 *
+	 * @access	public
+	 * @param	string
+	 * @param	string
+	 * @param	string
+	 * @return	mixed
+	 */
 	function str_putcsv($input, $delimiter = ',', $enclosure = '"')
 	{
 		// Open a memory "file" for read/write...

--- a/fuel/modules/fuel/helpers/convert_helper.php
+++ b/fuel/modules/fuel/helpers/convert_helper.php
@@ -32,15 +32,15 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Convert ascii characters to hex values
- *
- * @access	public
- * @param	string	string containing ascii characters
- * @return	string
- */	
 if (!function_exists('ascii_to_hex'))
 {
+	/**
+	 * Convert ascii characters to hex values
+	 *
+	 * @access	public
+	 * @param	string	string containing ascii characters
+	 * @return	string
+	 */
 	function ascii_to_hex($ascii)
 	{
 		$hex = '';
@@ -55,15 +55,15 @@ if (!function_exists('ascii_to_hex'))
 
 // --------------------------------------------------------------------
 
-/**
- * Convert ascii characters to hex values
- *
- * @access	public
- * @param	string	string containing ascii characters
- * @return	string
- */	   
 if (!function_exists('hex_to_ascii'))
 {
+	/**
+	 * Convert ascii characters to hex values
+	 *
+	 * @access	public
+	 * @param	string	string containing ascii characters
+	 * @return	string
+	 */
 	function hex_to_ascii($hex)
 	{
 		$ascii = '';
@@ -83,16 +83,16 @@ if (!function_exists('hex_to_ascii'))
 
 // --------------------------------------------------------------------
 
-/**
- * Convert a string into a safe, encoded uri value
- *
- * @access	public
- * @param	string	string to be converted
- * @param	boolean	convert to hex value 
- * @return	string
- */
 if (!function_exists('uri_safe_encode'))
 {
+	/**
+	 * Convert a string into a safe, encoded uri value
+	 *
+	 * @access	public
+	 * @param	string	string to be converted
+	 * @param	boolean	convert to hex value
+	 * @return	string
+	 */
 	function uri_safe_encode($str, $hexify = TRUE)
 	{
 		$str = ($hexify) ? ascii_to_hex(base64_encode($str)) : base64_encode($str);
@@ -102,16 +102,16 @@ if (!function_exists('uri_safe_encode'))
 
 // --------------------------------------------------------------------
 
-/**
- * Decode a base64 encoded string
- *
- * @access	public
- * @param	string	string to be converted
- * @param	boolean	value is hexified 
- * @return	string
- */
 if (!function_exists('uri_safe_decode'))
 {
+	/**
+	 * Decode a base64 encoded string
+	 *
+	 * @access	public
+	 * @param	string	string to be converted
+	 * @param	boolean	value is hexified
+	 * @return	string
+	 */
 	function uri_safe_decode($str, $hexify = TRUE)
 	{
 		$str = ($hexify) ? base64_decode(hex_to_ascii($str)) : base64_decode($str);
@@ -121,16 +121,16 @@ if (!function_exists('uri_safe_decode'))
 
 // --------------------------------------------------------------------
 
-/**
- * Encode a key/value array or string into a URI safe value
- *
- * @access	public
- * @param	string	string to be converted
- * @param	boolean	value is hexified 
- * @return	string
- */
 if (!function_exists('uri_safe_batch_encode'))
 {
+	/**
+	 * Encode a key/value array or string into a URI safe value
+	 *
+	 * @access	public
+	 * @param	string	string to be converted
+	 * @param	boolean	value is hexified
+	 * @return	string
+	 */
 	function uri_safe_batch_encode($uri, $delimiter = '|', $hexify = TRUE)
 	{
 		$str = '';
@@ -159,17 +159,17 @@ if (!function_exists('uri_safe_batch_encode'))
 
 // --------------------------------------------------------------------
 
-/**
- * Decode a key/value array or string into a URI safe value
- *
- * @access	public
- * @param	string	string to be converted
- * @param	string	delimiter to split string 
- * @param	boolean	value is hexified 
- * @return	string
- */
 if (!function_exists('uri_safe_batch_decode'))
 {
+	/**
+	 * Decode a key/value array or string into a URI safe value
+	 *
+	 * @access	public
+	 * @param	string	string to be converted
+	 * @param	string	delimiter to split string
+	 * @param	boolean	value is hexified
+	 * @return	string
+	 */
 	function uri_safe_batch_decode($str, $delimiter = '|', $hexify = TRUE)
 	{
 		$str = uri_safe_decode($str, $hexify);

--- a/fuel/modules/fuel/helpers/convert_helper.php
+++ b/fuel/modules/fuel/helpers/convert_helper.php
@@ -128,7 +128,7 @@ if (!function_exists('uri_safe_batch_encode'))
 	 *
 	 * @access	public
 	 * @param	string	string to be converted
-	 * @param   string  delimiter to join values with
+	 * @param	string	delimiter to join values with
 	 * @param	boolean	value is hexified
 	 * @return	string
 	 */

--- a/fuel/modules/fuel/helpers/convert_helper.php
+++ b/fuel/modules/fuel/helpers/convert_helper.php
@@ -128,6 +128,7 @@ if (!function_exists('uri_safe_batch_encode'))
 	 *
 	 * @access	public
 	 * @param	string	string to be converted
+	 * @param   string  delimiter to join values with
 	 * @param	boolean	value is hexified
 	 * @return	string
 	 */
@@ -168,7 +169,7 @@ if (!function_exists('uri_safe_batch_decode'))
 	 * @param	string	string to be converted
 	 * @param	string	delimiter to split string
 	 * @param	boolean	value is hexified
-	 * @return	string
+	 * @return	array
 	 */
 	function uri_safe_batch_decode($str, $delimiter = '|', $hexify = TRUE)
 	{

--- a/fuel/modules/fuel/helpers/format_helper.php
+++ b/fuel/modules/fuel/helpers/format_helper.php
@@ -34,8 +34,11 @@ if (!function_exists('currency'))
 	 * Formats value into a currency string
 	 *
 	 * @access	public
-	 * @param	string
+	 * @param	string  value to format
+	 * @param   string  currency symbol
 	 * @param	bool	whether to include the cents or not
+	 * @param   string  decimal separator
+	 * @param   string  thousands separator
 	 * @return	string
 	 */
 	function currency($value, $symbol = '$',  $include_cents = TRUE, $decimal_sep = '.', $thousands_sep = ',')

--- a/fuel/modules/fuel/helpers/format_helper.php
+++ b/fuel/modules/fuel/helpers/format_helper.php
@@ -26,8 +26,6 @@
  * @link		http://docs.getfuelcms.com/helpers/format_helper
  */
 
-
-
 // ------------------------------------------------------------------------
 
 if (!function_exists('currency'))

--- a/fuel/modules/fuel/helpers/format_helper.php
+++ b/fuel/modules/fuel/helpers/format_helper.php
@@ -34,11 +34,11 @@ if (!function_exists('currency'))
 	 * Formats value into a currency string
 	 *
 	 * @access	public
-	 * @param	string  value to format
-	 * @param   string  currency symbol
+	 * @param	string	value to format
+	 * @param	string	currency symbol
 	 * @param	bool	whether to include the cents or not
-	 * @param   string  decimal separator
-	 * @param   string  thousands separator
+	 * @param	string	decimal separator
+	 * @param	string	thousands separator
 	 * @return	string
 	 */
 	function currency($value, $symbol = '$',  $include_cents = TRUE, $decimal_sep = '.', $thousands_sep = ',')

--- a/fuel/modules/fuel/helpers/format_helper.php
+++ b/fuel/modules/fuel/helpers/format_helper.php
@@ -30,16 +30,16 @@
 
 // ------------------------------------------------------------------------
 
-/**
- * Formats value into a currency string
- *
- * @access	public
- * @param	string
- * @param	bool	whether to include the cents or not
- * @return	string
- */
 if (!function_exists('currency'))
 {
+	/**
+	 * Formats value into a currency string
+	 *
+	 * @access	public
+	 * @param	string
+	 * @param	bool	whether to include the cents or not
+	 * @return	string
+	 */
 	function currency($value, $symbol = '$',  $include_cents = TRUE, $decimal_sep = '.', $thousands_sep = ',')
 	{
 		if (!isset($value) OR $value === "")

--- a/fuel/modules/fuel/helpers/fuel_helper.php
+++ b/fuel/modules/fuel/helpers/fuel_helper.php
@@ -55,679 +55,737 @@ function &FUEL()
 
 // --------------------------------------------------------------------
 
-/**
- * Allows you to load a view and pass data to it.
- *
- * The <dfn>params</dfn> parameter can either be string value (in which case it will assume it is the name of the block view file) or an associative array that can have the following values:
-
-<ul>
-	<li><strong>view</strong> - the name of the view block file. Also can be the first parameter of the method</li>
-	<li><strong>vars</strong>: an array of variables to pass to the block. Also can be the second parameter of the method.</li>
-	<li><strong>view_string</strong> - a string variable that represents the block</li>
-	<li><strong>model</strong> - the name of a model to automatically load for the block</li>
-	<li><strong>find</strong> - the name of the find method to run on the loaded model</li>
-	<li><strong>select</strong> - select parameters to run for the find method</li>
-	<li><strong>where</strong> - where parameters to run for the find method</li>
-	<li><strong>order</strong> - the order the find method should return</li>
-	<li><strong>limit</strong> - the limit number of results to be returned by the find method</li>
-	<li><strong>offset</strong> - the find results returned offset value</li>
-	<li><strong>return_method</strong>: the return method the find query should use</li>
-	<li><strong>assoc_key</strong>: the column name to be used as the associative key in the find method</li>
-	<li><strong>data</strong>: the data values to be passed to the block. This variable get's automatically set if you specify the model and find method</li>
-	<li><strong>editable</strong>: css class styles to apply to menu items... can be a nested array</li>
-	<li><strong>parse</strong>: determines whether to parse the contents of the block. The default is set to 'auto'</li>
-	<li><strong>cache</strong>: determines whether to cache the block. Default is false</li>
-	<li><strong>mode</strong>: explicitly will look in either the CMS or the views/_blocks folder</li>
-	<li><strong>module</strong>: the name of the module to look in for the block</li>
-	<li><strong>language</strong>: the language version to use for the block. Must be a value specified found in the 'languages' options in the FUEL configuration</li>
-	<li><strong>use_default</strong>: determines whether to find a non-language specified version of a block with the same name if the specified language version is not available in the CMS</li>
-</ul>
- *
- * @access	public
- * @param	array
- * @param	array
- * @param	boolean
- * @param	string
- * @return	string
- */
-function fuel_block($params, $vars = array(), $check_db = TRUE, $scope = NULL)
+if ( ! function_exists('fuel_block'))
 {
-	$CI =& get_instance();
-	return $CI->fuel->blocks->render($params, $vars, $check_db, $scope);
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Creates a menu structure
- * 
- * The <dfn>params</dfn> parameter is an array of options to be used with the <a href="[user_guide_url]libraries/menu">Menu class</a>.
- * If FUEL's configuration mode is set to either <dfn>auto</dfn> or <dfn>cms</dfn>, then it will first look for data from the FUEL navigation module. 
- * Otherwise it will by default look for the file <dfn>views/_variables/nav.php</dfn> (you can change the name of the file it looks for in the <dfn>file</dfn> parameter passed). That file should contain an array of menu information (see <a href="<?=user_guide_url('libraries/menu')?>">Menu class</a> for more information on the required data structure). 
- * The parameter values are very similar to the <a href="[user_guide_url]libraries/menu">Menu class</a>, with a few additions shown below:
-
-<ul>
-		<li><strong>items</strong> - the navigation items to use. By default, this is empty and will look for the nav.php file or the records in the Navigation module</li>
-		<li><strong>file</strong> - the name of the file containing the navigation information</li>
-		<li><strong>var</strong> - the variable name in the file to use</li>
-		<li><strong>parent</strong> - the parent id you would like to start rendering from. This is either the database ID or the nav array key of the menu item</li>
-		<li><strong>root</strong> - the equivalent to the root_value attribute in the Menu class. It states what the root value of the menu structure should be. Normally you don't need to worry about this</li>
-		<li><strong>group_id</strong> - the group ID in the database to use. The default is <dfn>1</dfn>. Only applies to navigation items saved in the admin</li>
-		<li><strong>exclude</strong> - nav items to exclude from the menu. Can be an array or a regular expression string</li>
-		<li><strong>return_normalized</strong> - returns the raw normalized array that gets used to generate the menu</li>
-		<li><strong>render_type</strong>: options are basic, breadcrumb, page_title, collapsible, delimited, array. Default is 'basic'</li>
-		<li><strong>active_class</strong>: the active css class. Default is 'active'</li>
-		<li><strong>active</strong>: the active menu item</li>
-		<li><strong>styles</strong>: css class styles to apply to menu items... can be a nested array</li>
-		<li><strong>first_class</strong>: the css class for the first menu item. Default is first</li>
-		<li><strong>last_class</strong>: the css class for the last menu item. Default is last</li>
-		<li><strong>depth</strong>: the depth of the menu to render at</li>
-		<li><strong>use_titles</strong>: use the title attribute in the links. Default is FALSE</li>
-		<li><strong>container_tag</strong>: the html tag for the container of a set of menu items. Default is ul</li>
-		<li><strong>container_tag_attrs</strong>: html attributes for the container tag</li>
-		<li><strong>container_tag_id</strong>: html container id</li>
-		<li><strong>container_tag_class</strong>: html container class</li>
-		<li><strong>subcontainer_tag_class</strong>: an array of css classes to apply to subcontainers</li>
-		<li><strong>cascade_selected</strong>: cascade the selected items. Default is TRUE</li>
-		<li><strong>include_hidden</strong>: include menu items with the hidden attribute. Default is FALSE</li>
-		<li><strong>item_tag</strong>: the html list item element. Default is 'li'</li>
-		<li><strong>item_id_prefix</strong>: the prefix to the item id</li>
-		<li><strong>item_id_key</strong>: either id or location. Default is 'id'</li>
-		<li><strong>use_nav_key</strong>: determines whether to use the nav_key or the location for the active state. Default is "AUTO"</li>
-		<li><strong>pre_render_func</strong>: function to apply to menu labels before rendering</li>
-		<li><strong>delimiter</strong>: the html element between the links </li>
-		<li><strong>arrow_class</strong>: the class for the arrows used in breadcrumb type menus</li>
-		<li><strong>display_current</strong>: determines whether to display the current active breadcrumb item</li>
-		<li><strong>home_link</strong>: the root home link</li>
-		<li><strong>append</strong>: appends additional menu items to those items already set (e.g. from the $nav array or from the navigation module). Good to use on dynamic pages where you need to dynamically set a navigation item for a page</li>
-		<li><strong>order</strong>: the order to display... for page_title ONLY</li>
-		<li><strong>language</strong>: select the appropriate language</li>
-		<li><strong>include_default_language</strong>: will merge in the default language with the results. Default is FALSE</li>
-		<li><strong>language_default_group</strong>: the default group to be used when including a default language. Default is FALSE</li>
-	</ul>
-
-<p class="important">For more information see the <a href="<?=user_guide_url('libraries/menu')?>">Menu class</a>.</p>
- *
- * @access	public
- * @param	array
- * @return	string
- */
-function fuel_nav($params = array())
-{
-	$CI =& get_instance();
-	return $CI->fuel->navigation->render($params);
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Generates a page using the Fuel_page class
- *
- * @access	public
- * @param	array
- * @param	array
- * @return	string
- */
-function fuel_page($location, $vars = array(), $params = array())
-{
-	$CI =& get_instance();
-	return $CI->fuel->pages->render($location, $vars, $params, TRUE);
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Creates a form using form builder
- *
- * @access	public
- * @param	mixed
- * @param	array
- * @param	array
- * @return	string
- */
-function fuel_form($fields, $values = array(), $params = array())
-{
-	$CI =& get_instance();
-	
-	// if a string is provided instead of array, we will assume it is a model
-	if (is_string($fields))
+	/**
+	 * Allows you to load a view and pass data to it.
+	 *
+	 * The <dfn>params</dfn> parameter can either be string value (in which case it will assume it is the name of the block view file) or an associative array that can have the following values:
+	 *
+	 * <ul>
+	 * <li><strong>view</strong> - the name of the view block file. Also can be the first parameter of the method</li>
+	 * <li><strong>vars</strong>: an array of variables to pass to the block. Also can be the second parameter of the method.</li>
+	 * <li><strong>view_string</strong> - a string variable that represents the block</li>
+	 * <li><strong>model</strong> - the name of a model to automatically load for the block</li>
+	 * <li><strong>find</strong> - the name of the find method to run on the loaded model</li>
+	 * <li><strong>select</strong> - select parameters to run for the find method</li>
+	 * <li><strong>where</strong> - where parameters to run for the find method</li>
+	 * <li><strong>order</strong> - the order the find method should return</li>
+	 * <li><strong>limit</strong> - the limit number of results to be returned by the find method</li>
+	 * <li><strong>offset</strong> - the find results returned offset value</li>
+	 * <li><strong>return_method</strong>: the return method the find query should use</li>
+	 * <li><strong>assoc_key</strong>: the column name to be used as the associative key in the find method</li>
+	 * <li><strong>data</strong>: the data values to be passed to the block. This variable get's automatically set if you specify the model and find method</li>
+	 * <li><strong>editable</strong>: css class styles to apply to menu items... can be a nested array</li>
+	 * <li><strong>parse</strong>: determines whether to parse the contents of the block. The default is set to 'auto'</li>
+	 * <li><strong>cache</strong>: determines whether to cache the block. Default is false</li>
+	 * <li><strong>mode</strong>: explicitly will look in either the CMS or the views/_blocks folder</li>
+	 * <li><strong>module</strong>: the name of the module to look in for the block</li>
+	 * <li><strong>language</strong>: the language version to use for the block. Must be a value specified found in the 'languages' options in the FUEL configuration</li>
+	 * <li><strong>use_default</strong>: determines whether to find a non-language specified version of a block with the same name if the specified language version is not available in the CMS</li>
+	 * </ul>
+	 *
+	 * @access	public
+	 * @param	array
+	 * @param	array
+	 * @param	boolean
+	 * @param	string
+	 * @return	string
+	 */
+	function fuel_block($params, $vars = array(), $check_db = TRUE, $scope = NULL)
 	{
-		$model = $fields;
-		if (substr($model, strlen($model) - 6) != '_model')
+		$CI =& get_instance();
+		return $CI->fuel->blocks->render($params, $vars, $check_db, $scope);
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_nav'))
+{
+	/**
+	 * Creates a menu structure
+	 *
+	 * The <dfn>params</dfn> parameter is an array of options to be used with the <a href="[user_guide_url]libraries/menu">Menu class</a>.
+	 * If FUEL's configuration mode is set to either <dfn>auto</dfn> or <dfn>cms</dfn>, then it will first look for data from the FUEL navigation module.
+	 * Otherwise it will by default look for the file <dfn>views/_variables/nav.php</dfn> (you can change the name of the file it looks for in the <dfn>file</dfn> parameter passed). That file should contain an array of menu information (see <a href="<?=user_guide_url('libraries/menu')?>">Menu class</a> for more information on the required data structure).
+	 * The parameter values are very similar to the <a href="[user_guide_url]libraries/menu">Menu class</a>, with a few additions shown below:
+	 *
+	 * <ul>
+	 * <li><strong>items</strong> - the navigation items to use. By default, this is empty and will look for the nav.php file or the records in the Navigation module</li>
+	 * <li><strong>file</strong> - the name of the file containing the navigation information</li>
+	 * <li><strong>var</strong> - the variable name in the file to use</li>
+	 * <li><strong>parent</strong> - the parent id you would like to start rendering from. This is either the database ID or the nav array key of the menu item</li>
+	 * <li><strong>root</strong> - the equivalent to the root_value attribute in the Menu class. It states what the root value of the menu structure should be. Normally you don't need to worry about this</li>
+	 * <li><strong>group_id</strong> - the group ID in the database to use. The default is <dfn>1</dfn>. Only applies to navigation items saved in the admin</li>
+	 * <li><strong>exclude</strong> - nav items to exclude from the menu. Can be an array or a regular expression string</li>
+	 * <li><strong>return_normalized</strong> - returns the raw normalized array that gets used to generate the menu</li>
+	 * <li><strong>render_type</strong>: options are basic, breadcrumb, page_title, collapsible, delimited, array. Default is 'basic'</li>
+	 * <li><strong>active_class</strong>: the active css class. Default is 'active'</li>
+	 * <li><strong>active</strong>: the active menu item</li>
+	 * <li><strong>styles</strong>: css class styles to apply to menu items... can be a nested array</li>
+	 * <li><strong>first_class</strong>: the css class for the first menu item. Default is first</li>
+	 * <li><strong>last_class</strong>: the css class for the last menu item. Default is last</li>
+	 * <li><strong>depth</strong>: the depth of the menu to render at</li>
+	 * <li><strong>use_titles</strong>: use the title attribute in the links. Default is FALSE</li>
+	 * <li><strong>container_tag</strong>: the html tag for the container of a set of menu items. Default is ul</li>
+	 * <li><strong>container_tag_attrs</strong>: html attributes for the container tag</li>
+	 * <li><strong>container_tag_id</strong>: html container id</li>
+	 * <li><strong>container_tag_class</strong>: html container class</li>
+	 * <li><strong>subcontainer_tag_class</strong>: an array of css classes to apply to subcontainers</li>
+	 * <li><strong>cascade_selected</strong>: cascade the selected items. Default is TRUE</li>
+	 * <li><strong>include_hidden</strong>: include menu items with the hidden attribute. Default is FALSE</li>
+	 * <li><strong>item_tag</strong>: the html list item element. Default is 'li'</li>
+	 * <li><strong>item_id_prefix</strong>: the prefix to the item id</li>
+	 * <li><strong>item_id_key</strong>: either id or location. Default is 'id'</li>
+	 * <li><strong>use_nav_key</strong>: determines whether to use the nav_key or the location for the active state. Default is "AUTO"</li>
+	 * <li><strong>pre_render_func</strong>: function to apply to menu labels before rendering</li>
+	 * <li><strong>delimiter</strong>: the html element between the links </li>
+	 * <li><strong>arrow_class</strong>: the class for the arrows used in breadcrumb type menus</li>
+	 * <li><strong>display_current</strong>: determines whether to display the current active breadcrumb item</li>
+	 * <li><strong>home_link</strong>: the root home link</li>
+	 * <li><strong>append</strong>: appends additional menu items to those items already set (e.g. from the $nav array or from the navigation module). Good to use on dynamic pages where you need to dynamically set a navigation item for a page</li>
+	 * <li><strong>order</strong>: the order to display... for page_title ONLY</li>
+	 * <li><strong>language</strong>: select the appropriate language</li>
+	 * <li><strong>include_default_language</strong>: will merge in the default language with the results. Default is FALSE</li>
+	 * <li><strong>language_default_group</strong>: the default group to be used when including a default language. Default is FALSE</li>
+	 * </ul>
+	 *
+	 * <p class="important">For more information see the <a href="<?=user_guide_url('libraries/menu')?>">Menu class</a>.</p>
+	 *
+	 * @access	public
+	 * @param	array	$params
+	 * @return	string
+	 */
+	function fuel_nav($params = array())
+	{
+		$CI =& get_instance();
+		return $CI->fuel->navigation->render($params);
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_page'))
+{
+	/**
+	 * Generates a page using the Fuel_page class
+	 *
+	 * @access	public
+	 * @param	string
+	 * @param	array
+	 * @param	array
+	 * @return	string
+	 */
+	function fuel_page($location, $vars = array(), $params = array())
+	{
+		$CI =& get_instance();
+		return $CI->fuel->pages->render($location, $vars, $params, TRUE);
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_form'))
+{
+	/**
+	 * Creates a form using form builder
+	 *
+	 * @access	public
+	 * @param	mixed
+	 * @param	array
+	 * @param	array
+	 * @return	string
+	 */
+	function fuel_form($fields, $values = array(), $params = array())
+	{
+		$CI =& get_instance();
+
+		// if a string is provided instead of array, we will assume it is a model
+		if (is_string($fields))
 		{
-			$model = $model.'_model';
-		}
-		$CI->load->model($model);
-		
-		// check if the model has a form_fields method on it first
-		if (!method_exists('form_fields', $CI->$model))
-		{
-			return '';
-		}
-		$fields = $CI->$model->form_fields();
-	}
-	$CI->load->library('form_builder', $params);
-	$CI->form_builder->set_fields($fields);
-	$CI->form_builder->set_field_values($values);
-	return $CI->form_builder->render();
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Loads a module model and creates a variable in the view that you can use to merge data. 
- *
- * The <dfn>params</dfn> parameter is an associative array that can have the following values:
- *
-<ul>
-	<li><strong>find</strong> - the find method to use on the module model. Options are "one", "key", "all" or any method name on the model that begins with "find_" (excluding "find_" from the value)</li>
-	<li><strong>select</strong> - the select condition to filter the results of the find query</li>
-	<li><strong>where</strong> - the where condition to be used in the find query</li>
-	<li><strong>order</strong> - order the data results and sort them </li>
-	<li><strong>limit</strong> - limit the number of data results returned</li>
-	<li><strong>offset</strong> - offset the data results</li>
-	<li><strong>return_method</strong> - the return method to use which can be an object or an array</li>
-	<li><strong>assoc_key</strong> - the field to be used as an associative key for the data results</li>
-	<li><strong>var</strong> - the variable name to assign the data returned from the module model query</li>
-	<li><strong>module</strong> - specifies the module folder name to find the model</li>
-</ul>
- * @access	public
- * @param	string
- * @param	mixed
- * @param	mixed
- * @return	mixed
- */
-function fuel_model($module, $params = array(), $where = array())
-{
-	$CI =& get_instance();
-	$module = $CI->fuel->modules->get($module, FALSE);
-	if ($module)
-	{
-		return $module->find($params, $where);
-	}
-	return FALSE;
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Sets a variable for all views to use (including layouts) no matter what view it is declared in. 
- * 
- * Using fuel_set_var in a layout field in the admin, will have no affect (e.g. {fuel_set_var('layout', 'my_layout')}).
- *
- * @access	public
- * @param	string
- * @param	array
- * @return	void
- */
-function fuel_set_var($key, $val = NULL)
-{
-	$CI =& get_instance();
-	if (strtoupper($CI->fuel->config('double_parse')) == 'AUTO')
-	{
-		$CI->fuel->set_config('double_parse', TRUE);
-	}
-
-	if (is_array($key))
-	{
-		$CI->load->vars($key);
-	}
-	else if (is_string($key))
-	{
-		$vars[$key] = $val;
-		$CI->load->vars($vars);
-	}
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Appends a value to an array variable for all views to use no matter what view it is declared in.
- *
-<code>
-	// EXAMPLE HEADER FILE
-	...
-	&lt;?php echo css(&#x27;main&#x27;); ?&gt;
-	&lt;?php echo css($css); ?&gt;
-
-	&lt;?php echo js(&#x27;jquery, main&#x27;); ?&gt;
-	&lt;?php echo js($js); ?&gt;
-	...
-
-	// Then in your view file
-	...
-	&lt;php
-	fuel_var_append('css', 'my_css_file.css');
-	fuel_var_append('js', 'my_js_file.js');
-	?&gt;
-	<h1>About our company</h1>
-	...
- </code>
- * @access	public
- * @param	string
- * @param	mixed
- * @return	void
- */
-function fuel_var_append($key, $value)
-{
-	$CI =& get_instance();
-	$vars = $CI->load->get_vars();
-	if (isset($vars[$key]) AND is_array($vars[$key]))
-	{
-		if (is_array($value))
-		{
-			$vars[$key] = array_merge($vars[$key], $value);
-		}
-		else
-		{
-			array_push($vars[$key], $value);
-		}
-		fuel_set_var($key, $vars[$key]);
-	}
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Returns a variable and allows for a default value.
- * Also creates inline editing marker.
- * The <dfn>default</dfn> parameter will be used if the variable does not exist.
- * The <dfn>edit_module</dfn> parameter specifies the module to include for inline editing.
- * The <dfn>evaluate</dfn> parameter specifies whether to evaluate any php in the variables.
- *
-<p class="important">You should not use this function inside of another function because you may get unexepected results. This is
-because it returns inline editing markers that later get parsed out by FUEL. For example:</p>
-
-<code>
-// NO
-&lt;a href="&lt;?=site_url(fuel_var('my_url'))?&gt;"&gt;my link&lt;/a&gt;
-
-// YES
-&lt;?=fuel_edit('my_url', 'Edit Link')?&gt; &lt;a href="&lt;?=site_url($my_url)?&gt;"&gt;my link&lt;/a&gt;
-</code>
-
- * @access	public
- * @param	string
- * @param	string
- * @param	boolean
- * @return	string
- */
-function fuel_var($key, $default = '', $edit_module = 'pagevariables', $evaluate = FALSE)
-{
-	$CI =& get_instance();
-	$CI->load->helper('inflector');
-
-	$key_arr = explode('|', $key);
-	$key = $key_arr[0];
-
-	if (isset($GLOBALS[$key]))
-	{
-		$val = $GLOBALS[$key];
-	}
-	else if ($CI->load->get_var($key))
-	{
-		$val = $CI->load->get_var($key);
-	}
-	else
-	{
-		$val = $default;
-	}
-	
-	if (is_string($val) AND $evaluate)
-	{
-		$val = eval_string($val);
-	}
-	else if (is_array($val) AND $evaluate)
-	{
-		if (isset($key_arr[1]))
-		{
-			if (isset($val[$key_arr[1]]))
+			$model = $fields;
+			if (substr($model, strlen($model) - 6) != '_model')
 			{
-				$val = $val[$key_arr[1]];
+				$model = $model . '_model';
+			}
+			$CI->load->model($model);
+
+			// check if the model has a form_fields method on it first
+			if ( ! method_exists('form_fields', $CI->$model))
+			{
+				return '';
+			}
+			$fields = $CI->$model->form_fields();
+		}
+		$CI->load->library('form_builder', $params);
+		$CI->form_builder->set_fields($fields);
+		$CI->form_builder->set_field_values($values);
+		return $CI->form_builder->render();
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_model'))
+{
+	/**
+	 * Loads a module model and creates a variable in the view that you can use to merge data.
+	 *
+	 * The <dfn>params</dfn> parameter is an associative array that can have the following values:
+	 *
+	 * <ul>
+	 * <li><strong>find</strong> - the find method to use on the module model. Options are "one", "key", "all" or any method name on the model that begins with "find_" (excluding "find_" from the value)</li>
+	 * <li><strong>select</strong> - the select condition to filter the results of the find query</li>
+	 * <li><strong>where</strong> - the where condition to be used in the find query</li>
+	 * <li><strong>order</strong> - order the data results and sort them </li>
+	 * <li><strong>limit</strong> - limit the number of data results returned</li>
+	 * <li><strong>offset</strong> - offset the data results</li>
+	 * <li><strong>return_method</strong> - the return method to use which can be an object or an array</li>
+	 * <li><strong>assoc_key</strong> - the field to be used as an associative key for the data results</li>
+	 * <li><strong>var</strong> - the variable name to assign the data returned from the module model query</li>
+	 * <li><strong>module</strong> - specifies the module folder name to find the model</li>
+	 * </ul>
+	 * @access	public
+	 * @param	string
+	 * @param	mixed
+	 * @param	mixed
+	 * @return	mixed
+	 */
+	function fuel_model($module, $params = array(), $where = array())
+	{
+		$CI =& get_instance();
+		$module = $CI->fuel->modules->get($module, FALSE);
+		if ($module)
+		{
+			return $module->find($params, $where);
+		}
+		return FALSE;
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_set_var'))
+{
+	/**
+	 * Sets a variable for all views to use (including layouts) no matter what view it is declared in.
+	 *
+	 * Using fuel_set_var in a layout field in the admin, will have no affect (e.g. {fuel_set_var('layout', 'my_layout')}).
+	 *
+	 * @access	public
+	 * @param	string
+	 * @param	array
+	 * @return	void
+	 */
+	function fuel_set_var($key, $val = NULL)
+	{
+		$CI =& get_instance();
+		if (strtoupper($CI->fuel->config('double_parse')) == 'AUTO')
+		{
+			$CI->fuel->set_config('double_parse', TRUE);
+		}
+
+		if (is_array($key))
+		{
+			$CI->load->vars($key);
+		}
+		else if (is_string($key))
+		{
+			$vars[$key] = $val;
+			$CI->load->vars($vars);
+		}
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_var_append'))
+{
+	/**
+	 * Appends a value to an array variable for all views to use no matter what view it is declared in.
+	 *
+	 * <code>
+	 * // EXAMPLE HEADER FILE
+	 * ...
+	 * &lt;?php echo css(&#x27;main&#x27;); ?&gt;
+	 * &lt;?php echo css($css); ?&gt;
+	 *
+	 * &lt;?php echo js(&#x27;jquery, main&#x27;); ?&gt;
+	 * &lt;?php echo js($js); ?&gt;
+	 * ...
+	 *
+	 * // Then in your view file
+	 * ...
+	 * &lt;php
+	 * fuel_var_append('css', 'my_css_file.css');
+	 * fuel_var_append('js', 'my_js_file.js');
+	 * ?&gt;
+	 * <h1>About our company</h1>
+	 * ...
+	 * </code>
+	 * @access	public
+	 * @param	string
+	 * @param	mixed
+	 * @return	void
+	 */
+	function fuel_var_append($key, $value)
+	{
+		$CI =& get_instance();
+		$vars = $CI->load->get_vars();
+		if (isset($vars[$key]) AND is_array($vars[$key]))
+		{
+			if (is_array($value))
+			{
+				$vars[$key] = array_merge($vars[$key], $value);
 			}
 			else
 			{
-				$val = $default;
+				array_push($vars[$key], $value);
+			}
+			fuel_set_var($key, $vars[$key]);
+		}
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_var'))
+{
+	/**
+	 * Returns a variable and allows for a default value.
+	 * Also creates inline editing marker.
+	 * The <dfn>default</dfn> parameter will be used if the variable does not exist.
+	 * The <dfn>edit_module</dfn> parameter specifies the module to include for inline editing.
+	 * The <dfn>evaluate</dfn> parameter specifies whether to evaluate any php in the variables.
+	 *
+	 * <p class="important">You should not use this function inside of another function because you may get unexepected results. This is
+	 * because it returns inline editing markers that later get parsed out by FUEL. For example:</p>
+	 *
+	 * <code>
+	 * // NO
+	 * &lt;a href="&lt;?=site_url(fuel_var('my_url'))?&gt;"&gt;my link&lt;/a&gt;
+	 *
+	 * // YES
+	 * &lt;?=fuel_edit('my_url', 'Edit Link')?&gt; &lt;a href="&lt;?=site_url($my_url)?&gt;"&gt;my link&lt;/a&gt;
+	 * </code>
+	 * @access	public
+	 * @param	string
+	 * @param	string
+	 * @param	string
+	 * @param	boolean
+	 * @return	string
+	 */
+	function fuel_var($key, $default = '', $edit_module = 'pagevariables', $evaluate = FALSE)
+	{
+		$CI =& get_instance();
+		$CI->load->helper('inflector');
+
+		$key_arr = explode('|', $key);
+		$key = $key_arr[0];
+
+		if (isset($GLOBALS[$key]))
+		{
+			$val = $GLOBALS[$key];
+		}
+		else if ($CI->load->get_var($key))
+		{
+			$val = $CI->load->get_var($key);
+		}
+		else
+		{
+			$val = $default;
+		}
+
+		if (is_string($val) AND $evaluate)
+		{
+			$val = eval_string($val);
+		}
+		else if (is_array($val) AND $evaluate)
+		{
+			if (isset($key_arr[1]))
+			{
+				if (isset($val[$key_arr[1]]))
+				{
+					$val = $val[$key_arr[1]];
+				}
+				else
+				{
+					$val = $default;
+				}
+			}
+			else
+			{
+				foreach ($val as $k => $v)
+				{
+					$val[$k] = eval_string($v);
+				}
+			}
+		}
+
+		if ($edit_module === TRUE) $edit_module = 'pagevariables';
+		if ( ! empty($edit_module) AND $CI->fuel->pages->mode() != 'views' AND ! defined('FUELIFY') OR (defined('FUELIFY') AND FUELIFY))
+		{
+			$marker = fuel_edit($key, humanize($key), $edit_module);
+		}
+		else
+		{
+			$marker = '';
+		}
+
+		if (is_string($val))
+		{
+			return $marker . $val;
+		}
+		else
+		{
+			if ( ! empty($marker))
+			{
+				// used to help with javascript positioning
+				$marker = '<span>' . $marker . '</span>';
+			}
+			return $marker;
+		}
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_edit'))
+{
+	/**
+	 * Sets a variable marker (pencil icon) in a page which can be used for inline editing.
+	 *
+	 * The <dfn>id</dfn> parameter is the unique id that will be used to query the module. You can also pass an id value
+	 * and a field like so <dfn>id|field</dfn>. This will display only a certain field instead of the entire module form.
+	 * Alternatively, you can now also just pass the entire object and it will generate the id, label, module and published values automatically.
+	 * The <dfn>is_published</dfn> parameter specifies whether to indicate with the pencil icon that the item is active/published
+	 * The <dfn>label</dfn> parameter specifies the label to display next to the pencil icon.
+	 * The <dfn>xOffset</dfn> and <dfn>yOffset</dfn> are pixel values to offset the pencil icon.
+	 *
+	 * @access	public
+	 * @param	mixed
+	 * @param	string
+	 * @param	string
+	 * @param	boolean
+	 * @param	int
+	 * @param	int
+	 * @return	string
+	 */
+	function fuel_edit($id, $label = NULL, $module = 'pagevariables', $is_published = TRUE, $xoffset = NULL, $yoffset = NULL)
+	{
+		$CI =& get_instance();
+		$page = $CI->fuel->pages->active();
+		$permission = $module;
+		if (empty($page))
+		{
+			$page = $CI->fuel->pages->create();
+		}
+		if ( ! empty($id) AND ( ! defined('FUELIFY') OR defined('FUELIFY') AND FUELIFY !== FALSE))
+		{
+			if (is_object($id) AND is_a($id, 'Data_record') AND isset($id->id))
+			{
+				$ref_id = $id->id;
+
+				if (empty($module) OR $module == 'pagevariables')
+				{
+					$module = $id->parent_model()->table_name();
+					$tables = array_flip($id->parent_model()->tables());
+					if (isset($tables[$module]))
+					{
+						$module = $tables[$module];
+					}
+					unset($tables);
+				}
+
+				if (empty($label))
+				{
+					$label = lang('action_edit') . ': ';
+
+					if (isset($id->title))
+					{
+						$label .= $id->title;
+					}
+					else if ($id->name)
+					{
+						$label .= $id->name;
+					}
+				}
+
+				if (isset($id->published))
+				{
+					$is_published = is_true_val($id->published);
+				}
+				else if (isset($id->active))
+				{
+					$is_published = is_true_val($id->active);
+				}
+			}
+			else
+			{
+				$ref_id = $id;
+			}
+
+			$mod = $CI->fuel->modules->get($module, FALSE);
+			if ( ! empty($mod))
+			{
+				$module = $mod->info('module_uri');
+				$permission = $mod->info('permission');
+			}
+
+			$marker['id'] = $ref_id;
+			$marker['label'] = $label;
+			$marker['module'] = $module;
+			$marker['permission'] = $permission;
+			$marker['published'] = $is_published;
+			$marker['xoffset'] = $xoffset;
+			$marker['yoffset'] = $yoffset;
+
+			$key = $page->add_marker($marker);
+
+			return '<!--' . $key . '-->';
+		}
+		return '';
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_cache_id'))
+{
+	/**
+	 * Creates the cache ID for the fuel page based on the URI.
+	 *
+	 * If no <dfn>location</dfn> value is passed, it will default to the current <a href="<?=user_guide_url('my_url_helper')?>">uri_path</a>.
+	 *
+	 * @access	public
+	 * @param	string
+	 * @return	string
+	 */
+	function fuel_cache_id($location = NULL)
+	{
+		$CI =& get_instance();
+		return $CI->fuel->cache->create_id($location);
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_url'))
+{
+	/**
+	 * Creates the admin URL for FUEL (e.g. http://localhost/MY_PROJECT/fuel/admin)
+	 *
+	 * @access	public
+	 * @param	string
+	 * @param	boolean
+	 * @return	string
+	 */
+	function fuel_url($uri = '', $query_string = FALSE)
+	{
+		$CI =& get_instance();
+		$uri = fuel_uri($uri, $query_string);
+		return site_url($uri, NULL, FALSE);
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_uri'))
+{
+	/**
+	 * Returns the FUEL admin URI path
+	 *
+	 * @access	public
+	 * @param	string
+	 * @param	boolean
+	 * @return	string
+	 */
+	function fuel_uri($uri = '', $query_string = FALSE)
+	{
+		$CI =& get_instance();
+		if (is_bool($query_string) AND $query_string !== FALSE)
+		{
+			$query_string = $_GET;
+		}
+		$q = '';
+		if ( ! empty($query_string))
+		{
+			if (is_array($query_string))
+			{
+				$q_str = http_build_query($query_string);
+				if ( ! empty($q_str))
+				{
+					$q = '?' . $q_str;
+				}
+			}
+			else if (is_string($query_string))
+			{
+				$q = (strncmp($query_string, '?', 1) !== 0) ? '?' . $query_string : $query_string;
+			}
+		}
+		return $CI->fuel->config('fuel_path') . $uri . $q;
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_uri_segment'))
+{
+	/**
+	 * Returns the uri segment based on the FUEL admin path
+	 *
+	 * @access	public
+	 * @param	int
+	 * @param	boolean
+	 * @return	string
+	 */
+	function fuel_uri_segment($seg_index = 0, $rerouted = FALSE)
+	{
+		$CI =& get_instance();
+		if ($rerouted)
+		{
+			return $CI->uri->rsegment(fuel_uri_index($seg_index));
+		}
+		else
+		{
+			return $CI->uri->segment(fuel_uri_index($seg_index));
+		}
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_uri_index'))
+{
+	/**
+	 * Returns the uri index number based on the FUEL admin path
+	 *
+	 * @access	public
+	 * @param	int
+	 * @return	int
+	 */
+	function fuel_uri_index($seg_index = 0)
+	{
+		$CI =& get_instance();
+		$fuel_path = $CI->fuel->config('fuel_path');
+		$start_index = count(explode('/', $fuel_path)) - 1;
+		return $start_index + $seg_index;
+	}
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_uri_string'))
+{
+	/**
+	 * Returns the uri string based on the FUEL admin path
+	 *
+	 * @access	public
+	 * @param	int
+	 * @param	int
+	 * @param	boolean
+	 * @return	string
+	 */
+	function fuel_uri_string($from = 0, $to = NULL, $rerouted = FALSE)
+	{
+		$CI =& get_instance();
+		$fuel_index = fuel_uri_index($from);
+
+		if ($rerouted)
+		{
+			$segs = $CI->uri->rsegment_array($fuel_index);
+		}
+		else
+		{
+			$segs = $CI->uri->segment_array($fuel_index);
+		}
+		$from = fuel_uri_index($from);
+		if (isset($to))
+		{
+			$to = fuel_uri_index($to);
+			if ($from < $to)
+			{
+				$to = $from;
 			}
 		}
 		else
 		{
-			foreach($val as $k => $v)
-			{
-				$val[$k] = eval_string($v);
-			}
+			$to = sizeof($segs);
 		}
-	}
-	
-	if ($edit_module === TRUE) $edit_module = 'pagevariables';
-	if (!empty($edit_module) AND $CI->fuel->pages->mode() != 'views' AND !defined('FUELIFY') OR (defined('FUELIFY') AND FUELIFY))
-	{
-		$marker = fuel_edit($key, humanize($key), $edit_module);
-	}
-	else
-	{
-		$marker = '';
-	}
-	
-	if (is_string($val))
-	{
-		return $marker.$val;
-	}
-	else
-	{
-		if (!empty($marker))
-		{
-			// used to help with javascript positioning
-			$marker = '<span>'.$marker.'</span>';
-		}
-		return $marker;
+		$segs = array_slice($segs, $from, $to);
+		$uri = implode('/', $segs);
+		return $uri;
 	}
 }
 
 // --------------------------------------------------------------------
 
-/**
- * Sets a variable marker (pencil icon) in a page which can be used for inline editing.
- * 
- * The <dfn>id</dfn> parameter is the unique id that will be used to query the module. You can also pass an id value
- * and a field like so <dfn>id|field</dfn>. This will display only a certain field instead of the entire module form.
- * Alternatively, you can now also just pass the entire object and it will generate the id, label, module and published values automatically.
- * The <dfn>is_published</dfn> parameter specifies whether to indicate with the pencil icon that the item is active/published
- * The <dfn>label</dfn> parameter specifies the label to display next to the pencil icon.
- * The <dfn>xOffset</dfn> and <dfn>yOffset</dfn> are pixel values to offset the pencil icon.
- *
- * @access	public
- * @param	mixed
- * @param	string
- * @param	string
- * @param	boolean
- * @param	int
- * @param	int
- * @return	string
- */
-function fuel_edit($id, $label = NULL, $module = 'pagevariables', $is_published = TRUE, $xoffset = NULL, $yoffset = NULL)
+if ( ! function_exists('is_fuelified'))
 {
-	$CI =& get_instance();
-	$page = $CI->fuel->pages->active();
-	$permission = $module;
-	if (empty($page))
+	/**
+	 * Check to see if you are logged in and can use inline editing
+	 *
+	 * @access	public
+	 * @return	boolean
+	 */
+	function is_fuelified()
 	{
-		$page = $CI->fuel->pages->create();
-	}
-	if (!empty($id) AND (!defined('FUELIFY') OR defined('FUELIFY') AND FUELIFY !== FALSE))
-	{
-		if (is_object($id) AND is_a($id, 'Data_record') AND isset($id->id))
-		{
-			$ref_id = $id->id;
-			
-			if (empty($module) OR $module == 'pagevariables')
-			{
-				$module = $id->parent_model()->table_name();
-				$tables = array_flip($id->parent_model()->tables());
-				if (isset($tables[$module]))
-				{
-					$module = $tables[$module];
-				}
-				unset($tables);
-			}
-			
-			if (empty($label))
-			{
-				$label = lang('action_edit').': ';
-
-				if (isset($id->title))
-				{
-					$label .= $id->title;
-				}
-				else if ($id->name)
-				{
-					$label .= $id->name;
-				}
-			}
-			
-			if (isset($id->published))
-			{
-				$is_published = is_true_val($id->published);
-			}
-			else if (isset($id->active))
-			{
-				$is_published = is_true_val($id->active);
-			}
-		}
-		else
-		{
-			$ref_id = $id;
-		}
-
-		$mod = $CI->fuel->modules->get($module, FALSE);
-		if (!empty($mod))
-		{
-			$module = $mod->info('module_uri');
-			$permission = $mod->info('permission');
-		}
-		
-		$marker['id'] = $ref_id;
-		$marker['label'] = $label;
-		$marker['module'] = $module;
-		$marker['permission'] = $permission;
-		$marker['published'] = $is_published;
-		$marker['xoffset'] = $xoffset;
-		$marker['yoffset'] = $yoffset;
-
-		$key = $page->add_marker($marker);
-
-		return '<!--'.$key.'-->';
-	}
-	return '';
-}
-
-// --------------------------------------------------------------------
-
-/**
- * 	Creates the cache ID for the fuel page based on the URI. 
- * 
- * If no <dfn>location</dfn> value is passed, it will default to the current <a href="<?=user_guide_url('my_url_helper')?>">uri_path</a>.
- *
- * @access	public
- * @param	string
- * @return	string
- */
-function fuel_cache_id($location = NULL)
-{
-	$CI =& get_instance();
-	return $CI->fuel->cache->create_id($location);
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Creates the admin URL for FUEL (e.g. http://localhost/MY_PROJECT/fuel/admin)
- *
- * @access	public
- * @param	string
- * @param	boolean
- * @return	string
- */
-function fuel_url($uri = '', $query_string = FALSE)
-{
-	$CI =& get_instance();
-	$uri = fuel_uri($uri, $query_string);
-	return site_url($uri, NULL, FALSE);
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Returns the FUEL admin URI path
- *
- * @access	public
- * @param	string
- * @param	boolean
- * @return	string
- */
-function fuel_uri($uri = '', $query_string = FALSE)
-{
-	$CI =& get_instance();
-	if (is_bool($query_string) AND $query_string !== FALSE)
-	{
-		$query_string = $_GET;
-	}
-	$q = '';
-	if (!empty($query_string))
-	{
-		if (is_array($query_string))
-		{
-			$q_str = http_build_query($query_string);
-			if (!empty($q_str))
-			{
-				$q = '?'.$q_str;
-			}
-		}
-		else if (is_string($query_string))
-		{
-			$q = (strncmp($query_string, '?', 1) !== 0) ? '?'.$query_string : $query_string;
-		}
-	}
-	return $CI->fuel->config('fuel_path').$uri.$q;
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Returns the uri segment based on the FUEL admin path
- *
- * @access	public
- * @param	int
- * @param	boolean
- * @return	string
- */
-function fuel_uri_segment($seg_index = 0, $rerouted = FALSE)
-{
-	$CI =& get_instance();
-	if ($rerouted)
-	{
-		return $CI->uri->rsegment(fuel_uri_index($seg_index));
-	}
-	else
-	{
-		return $CI->uri->segment(fuel_uri_index($seg_index));
+		$CI =& get_instance();
+		return $CI->fuel->auth->is_fuelified();
 	}
 }
 
 // --------------------------------------------------------------------
 
-/**
- * Returns the uri index number based on the FUEL admin path
- *
- * @access	public
- * @param	int
- * @return	int
- */
-function fuel_uri_index($seg_index = 0)
+if ( ! function_exists('in_fuel_admin'))
 {
-	$CI =& get_instance();
-	$fuel_path = $CI->fuel->config('fuel_path');
-	$start_index = count(explode('/', $fuel_path)) - 1;
-	return $start_index + $seg_index;
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Returns the uri string based on the FUEL admin path
- *
- * @access	public
- * @param	int
- * @param	int
- * @param	boolean
- * @return	string
- */
-function fuel_uri_string($from = 0, $to = NULL, $rerouted = FALSE)
-{
-	$CI =& get_instance();
-	$fuel_index = fuel_uri_index($from);
-	
-	if ($rerouted)
+	/**
+	 * Check to see if you are in the FUEL admin
+	 *
+	 * @access	public
+	 * @return	boolean
+	 */
+	function in_fuel_admin()
 	{
-		$segs = $CI->uri->rsegment_array($fuel_index);
+		return (defined('FUEL_ADMIN') AND FUEL_ADMIN === TRUE);
 	}
-	else
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_user_lang'))
+{
+	/**
+	 * Returns the user language of the person logged in... used for inline editing
+	 *
+	 * @access	public
+	 * @return	string
+	 */
+	function fuel_user_lang()
 	{
-		$segs = $CI->uri->segment_array($fuel_index);
+		$CI =& get_instance();
+		return $CI->fuel->auth->user_lang();
 	}
-	$from = fuel_uri_index($from);
-	if (isset($to))
+}
+
+// --------------------------------------------------------------------
+
+if ( ! function_exists('fuel_settings'))
+{
+	/**
+	 * Returns the setting(s) for a particular module
+	 *
+	 * @access	public
+	 * @param	string	Module name
+	 * @param	string	Settings key (optional)
+	 * @return	mixed
+	 */
+	function fuel_settings($module, $key = '')
 	{
-		$to = fuel_uri_index($to);
-		if ($from < $to)
-		{
-			$to = $from;
-		}
+		$CI =& get_instance();
+		return $CI->fuel->settings->get($module, $key);
 	}
-	else
-	{
-		$to = sizeof($segs);
-	}
-	$segs = array_slice($segs, $from, $to);
-	$uri = implode('/', $segs);
-	return $uri;
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Check to see if you are logged in and can use inline editing
- *
- * @access	public
- * @return	boolean
- */
-function is_fuelified()
-{
-	$CI =& get_instance();
-	return $CI->fuel->auth->is_fuelified();
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Check to see if you are in the FUEL admin
- *
- * @access	public
- * @return	boolean
- */
-function in_fuel_admin()
-{
-	return (defined('FUEL_ADMIN') AND FUEL_ADMIN === TRUE);
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Returns the user language of the person logged in... used for inline editing
- *
- * @access	public
- * @return	string
- */
-function fuel_user_lang()
-{
-	$CI =& get_instance();
-	return $CI->fuel->auth->user_lang();
-}
-
-// --------------------------------------------------------------------
-
-/**
- * Returns the setting(s) for a particular module
- *
- * @access	public
- * @param	string	Module name
- * @param	string	Settings key (optional)
- * @return	mixed
- */
-function fuel_settings($module, $key = '')
-{
-	$CI =& get_instance();
-	return $CI->fuel->settings->get($module, $key);
 }
 
 /* End of file fuel_helper.php */

--- a/fuel/modules/fuel/helpers/google_helper.php
+++ b/fuel/modules/fuel/helpers/google_helper.php
@@ -28,22 +28,22 @@
 
 // --------------------------------------------------------------------
 
-/**
-* Google Universal Analytics
-*
-* Inserts google universal analytics tracking code into view
-* If a tracking code is passed in, then it will use that uacct info
-* Otherwise, it will use the value defined in the google.php config file
-* If both values do not exist, nothing will be inserted.
-*
-* @access    public
-* @param    string	The google account number (optional)
-* @param    mixed	An array or string of extra parameters to pass to GA. An array will use the key/value to add _gaq.push (optional)
-* @param    boolean	Whether to check dev mode before adding it in (optional)
-* @return   string
-*/
 if (!function_exists('google_uanalytics'))
 {
+	/**
+	* Google Universal Analytics
+	*
+	* Inserts google universal analytics tracking code into view
+	* If a tracking code is passed in, then it will use that uacct info
+	* Otherwise, it will use the value defined in the google.php config file
+	* If both values do not exist, nothing will be inserted.
+	*
+	* @access    public
+	* @param    string	The google account number (optional)
+	* @param    mixed	An array or string of extra parameters to pass to GA. An array will use the key/value to add _gaq.push (optional)
+	* @param    boolean	Whether to check dev mode before adding it in (optional)
+	* @return   string
+	*/
 	function google_uanalytics($uacct = '', $other_params = array(), $check_devmode = TRUE) {
 
 		if ($check_devmode AND (function_exists('is_dev_mode') AND is_dev_mode()))
@@ -105,22 +105,22 @@ if (!function_exists('google_uanalytics'))
 
 // ------------------------------------------------------------------------
 
-/**
-* Google Analytics
-*
-* Inserts google analytics tracking code into view
-* If a tracking code is passed in, then it will use that uacct info
-* Otherwise, it will use the value defined in the google.php config file
-* If both values do not exist, nothing will be inserted.
-*
-* @access    public
-* @param    string	The google account number (optional)
-* @param    mixed	An array or string of extra parameters to pass to GA. An array will use the key/value to add _gaq.push (optional)
-* @param    boolean	Whether to check dev mode before adding it in (optional)
-* @return   string
-*/
 if (!function_exists('google_analytics'))
 {
+	/**
+	* Google Analytics
+	*
+	* Inserts google analytics tracking code into view
+	* If a tracking code is passed in, then it will use that uacct info
+	* Otherwise, it will use the value defined in the google.php config file
+	* If both values do not exist, nothing will be inserted.
+	*
+	* @access    public
+	* @param    string	The google account number (optional)
+	* @param    mixed	An array or string of extra parameters to pass to GA. An array will use the key/value to add _gaq.push (optional)
+	* @param    boolean	Whether to check dev mode before adding it in (optional)
+	* @return   string
+	*/
 	function google_analytics($uacct = '', $other_params = array(), $check_devmode = TRUE) {
 		/*
 		 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -186,18 +186,18 @@ if (!function_exists('google_analytics'))
 
 // ------------------------------------------------------------------------
 
-/**
-* Google map
-*
-* Returns an iframed Google map
-*
-* @access    public
-* @param    mixed	Address can be either an array with "address", "city", "state" or simply a string
-* @param    array	An array of additional map parameter that that includes, "height", "width", hl" (language), "z" (zoom), "t" (map type), "om", (overview map), "iwloc" (display info bubble), "ll" (lat,lng). Friendly names of "display_info" (iwloc), "map_type" (t), and "overview" (om) can be used. (optional)
-* @return   string
-*/
 if (!function_exists('google_map'))
 {
+	/**
+	* Google map
+	*
+	* Returns an iframed Google map
+	*
+	* @access    public
+	* @param    mixed	Address can be either an array with "address", "city", "state" or simply a string
+	* @param    array	An array of additional map parameter that that includes, "height", "width", hl" (language), "z" (zoom), "t" (map type), "om", (overview map), "iwloc" (display info bubble), "ll" (lat,lng). Friendly names of "display_info" (iwloc), "map_type" (t), and "overview" (om) can be used. (optional)
+	* @return   string
+	*/
 	function google_map($address, $params = array())
 	{
 		// get either the custom map url or the standard google url
@@ -219,18 +219,18 @@ if (!function_exists('google_map'))
 
 // ------------------------------------------------------------------------
 
-/**
-* Google map URL
-*
-* Returns a google map URL (used by the google_map function too)
-*
-* @access    public
-* @param    mixed	Address can be either an array with "address", "city", "state" or simply a string. You can also pass lat and lng values as an array
-* @param    array	An array of additional map parameter that that includes, "hl" (language), "z" (zoom), "t" (map type), "om", (overview map), "iwloc" (display info bubble), "ll" (lat,lng). Friendly names of "display_info" (iwloc), "map_type" (t), and "overview" (om) can be used. (optional)
-* @return   string
-*/
 if (!function_exists('google_map_url'))
 {
+	/**
+	* Google map URL
+	*
+	* Returns a google map URL (used by the google_map function too)
+	*
+	* @access    public
+	* @param    mixed	Address can be either an array with "address", "city", "state" or simply a string. You can also pass lat and lng values as an array
+	* @param    array	An array of additional map parameter that that includes, "hl" (language), "z" (zoom), "t" (map type), "om", (overview map), "iwloc" (display info bubble), "ll" (lat,lng). Friendly names of "display_info" (iwloc), "map_type" (t), and "overview" (om) can be used. (optional)
+	* @return   string
+	*/
 	function google_map_url($address, $params = array())
 	{
 		// if a query string is passed, then we parse it into an array form
@@ -333,20 +333,20 @@ if (!function_exists('google_map_url'))
 
 // ------------------------------------------------------------------------
 
-/**
-* Google geolocate
-*
-* Finds the latitude and longitude of a given address. 
-* Use sleep() or usleep() functions to meter multiple requests (10/s is limit I believe)
-* More on the return types here: https://developers.google.com/maps/documentation/geocoding/
-*
-* @access    public
-* @param    mixed	Address can be either an array with "address", "city", "state" or simply a string
-* @param    mixed	Return type can be 'all' (default), 'address_components', 'formatted_address', 'geometry', 'location', 'street_number', 'route', 'neighborhood', 'city',  'county', 'state', 'country', 'zip' (optional)
-* @return   mixed  usually an array (e.g. array('latitude' => xxxx, 'longitude' => xxxx))
-*/
 if (!function_exists('google_geolocate'))
 {
+	/**
+	* Google geolocate
+	*
+	* Finds the latitude and longitude of a given address.
+	* Use sleep() or usleep() functions to meter multiple requests (10/s is limit I believe)
+	* More on the return types here: https://developers.google.com/maps/documentation/geocoding/
+	*
+	* @access    public
+	* @param    mixed	Address can be either an array with "address", "city", "state" or simply a string
+	* @param    mixed	Return type can be 'all' (default), 'address_components', 'formatted_address', 'geometry', 'location', 'street_number', 'route', 'neighborhood', 'city',  'county', 'state', 'country', 'zip' (optional)
+	* @return   mixed  usually an array (e.g. array('latitude' => xxxx, 'longitude' => xxxx))
+	*/
 	function google_geolocate($data, $return = 'all', $long = TRUE)
 	{
 		$address = '';

--- a/fuel/modules/fuel/helpers/google_helper.php
+++ b/fuel/modules/fuel/helpers/google_helper.php
@@ -38,11 +38,11 @@ if (!function_exists('google_uanalytics'))
 	* Otherwise, it will use the value defined in the google.php config file
 	* If both values do not exist, nothing will be inserted.
 	*
-	* @access   public
-	* @param    string	The google account number (optional)
-	* @param    mixed	An array or string of extra parameters to pass to GA. An array will use the key/value to add _gaq.push (optional)
-	* @param    boolean	Whether to check dev mode before adding it in (optional)
-	* @return   string
+	* @access	public
+	* @param	string	The google account number (optional)
+	* @param	mixed	An array or string of extra parameters to pass to GA. An array will use the key/value to add _gaq.push (optional)
+	* @param	boolean	Whether to check dev mode before adding it in (optional)
+	* @return	string
 	*/
 	function google_uanalytics($uacct = '', $other_params = array(), $check_devmode = TRUE) {
 
@@ -115,11 +115,11 @@ if (!function_exists('google_analytics'))
 	* Otherwise, it will use the value defined in the google.php config file
 	* If both values do not exist, nothing will be inserted.
 	*
-	* @access   public
-	* @param    string	The google account number (optional)
-	* @param    mixed	An array or string of extra parameters to pass to GA. An array will use the key/value to add _gaq.push (optional)
-	* @param    boolean	Whether to check dev mode before adding it in (optional)
-	* @return   string
+	* @access	public
+	* @param	string	The google account number (optional)
+	* @param	mixed	An array or string of extra parameters to pass to GA. An array will use the key/value to add _gaq.push (optional)
+	* @param	boolean	Whether to check dev mode before adding it in (optional)
+	* @return	string
 	*/
 	function google_analytics($uacct = '', $other_params = array(), $check_devmode = TRUE) {
 		/*
@@ -193,10 +193,10 @@ if (!function_exists('google_map'))
 	*
 	* Returns an iframed Google map
 	*
-	* @access   public
-	* @param    mixed	address can be either an array with "address", "city", "state" or simply a string
-	* @param    array	additional map parameters that include "height", "width", hl" (language), "z" (zoom), "t" (map type), "om", (overview map), "iwloc" (display info bubble), "ll" (lat,lng). Friendly names of "display_info" (iwloc), "map_type" (t), and "overview" (om) can be used. (optional)
-	* @return   string
+	* @access	public
+	* @param	mixed	address can be either an array with "address", "city", "state" or simply a string
+	* @param	array	additional map parameters that include "height", "width", hl" (language), "z" (zoom), "t" (map type), "om", (overview map), "iwloc" (display info bubble), "ll" (lat,lng). Friendly names of "display_info" (iwloc), "map_type" (t), and "overview" (om) can be used. (optional)
+	* @return	string
 	*/
 	function google_map($address, $params = array())
 	{
@@ -226,10 +226,10 @@ if (!function_exists('google_map_url'))
 	*
 	* Returns a google map URL (used by the google_map function too)
 	*
-	* @access   public
-	* @param    mixed	address can be either an array with "address", "city", "state" or simply a string. You can also pass lat and lng values as an array
-	* @param    array	additional map parameters that include "hl" (language), "z" (zoom), "t" (map type), "om", (overview map), "iwloc" (display info bubble), "ll" (lat,lng). Friendly names of "display_info" (iwloc), "map_type" (t), and "overview" (om) can be used. (optional)
-	* @return   string
+	* @access	public
+	* @param	mixed	address can be either an array with "address", "city", "state" or simply a string. You can also pass lat and lng values as an array
+	* @param	array	additional map parameters that include "hl" (language), "z" (zoom), "t" (map type), "om", (overview map), "iwloc" (display info bubble), "ll" (lat,lng). Friendly names of "display_info" (iwloc), "map_type" (t), and "overview" (om) can be used. (optional)
+	* @return	string
 	*/
 	function google_map_url($address, $params = array())
 	{
@@ -342,11 +342,11 @@ if (!function_exists('google_geolocate'))
 	* Use sleep() or usleep() functions to meter multiple requests (10/s is limit I believe)
 	* More on the return types here: https://developers.google.com/maps/documentation/geocoding/
 	*
-	* @access   public
-	* @param    mixed	address can be either an array with "address", "city", "state" or simply a string
-	* @param    mixed	return type can be 'all' (default), 'address_components', 'formatted_address', 'geometry', 'location', 'street_number', 'route', 'neighborhood', 'city',  'county', 'state', 'country', 'zip' (optional)
-	* @param    bool    whether to return value under 'short_name' or 'long_name' if defined in result
-	* @return   mixed   usually an array (e.g. array('latitude' => xxxx, 'longitude' => xxxx))
+	* @access	public
+	* @param	mixed	address can be either an array with "address", "city", "state" or simply a string
+	* @param	mixed	return type can be 'all' (default), 'address_components', 'formatted_address', 'geometry', 'location', 'street_number', 'route', 'neighborhood', 'city',  'county', 'state', 'country', 'zip' (optional)
+	* @param	bool	whether to return value under 'short_name' or 'long_name' if defined in result
+	* @return	mixed	usually an array (e.g. array('latitude' => xxxx, 'longitude' => xxxx))
 	*/
 	function google_geolocate($data, $return = 'all', $long = TRUE)
 	{

--- a/fuel/modules/fuel/helpers/google_helper.php
+++ b/fuel/modules/fuel/helpers/google_helper.php
@@ -38,7 +38,7 @@ if (!function_exists('google_uanalytics'))
 	* Otherwise, it will use the value defined in the google.php config file
 	* If both values do not exist, nothing will be inserted.
 	*
-	* @access    public
+	* @access   public
 	* @param    string	The google account number (optional)
 	* @param    mixed	An array or string of extra parameters to pass to GA. An array will use the key/value to add _gaq.push (optional)
 	* @param    boolean	Whether to check dev mode before adding it in (optional)
@@ -115,7 +115,7 @@ if (!function_exists('google_analytics'))
 	* Otherwise, it will use the value defined in the google.php config file
 	* If both values do not exist, nothing will be inserted.
 	*
-	* @access    public
+	* @access   public
 	* @param    string	The google account number (optional)
 	* @param    mixed	An array or string of extra parameters to pass to GA. An array will use the key/value to add _gaq.push (optional)
 	* @param    boolean	Whether to check dev mode before adding it in (optional)
@@ -193,9 +193,9 @@ if (!function_exists('google_map'))
 	*
 	* Returns an iframed Google map
 	*
-	* @access    public
-	* @param    mixed	Address can be either an array with "address", "city", "state" or simply a string
-	* @param    array	An array of additional map parameter that that includes, "height", "width", hl" (language), "z" (zoom), "t" (map type), "om", (overview map), "iwloc" (display info bubble), "ll" (lat,lng). Friendly names of "display_info" (iwloc), "map_type" (t), and "overview" (om) can be used. (optional)
+	* @access   public
+	* @param    mixed	address can be either an array with "address", "city", "state" or simply a string
+	* @param    array	additional map parameters that include "height", "width", hl" (language), "z" (zoom), "t" (map type), "om", (overview map), "iwloc" (display info bubble), "ll" (lat,lng). Friendly names of "display_info" (iwloc), "map_type" (t), and "overview" (om) can be used. (optional)
 	* @return   string
 	*/
 	function google_map($address, $params = array())
@@ -226,9 +226,9 @@ if (!function_exists('google_map_url'))
 	*
 	* Returns a google map URL (used by the google_map function too)
 	*
-	* @access    public
-	* @param    mixed	Address can be either an array with "address", "city", "state" or simply a string. You can also pass lat and lng values as an array
-	* @param    array	An array of additional map parameter that that includes, "hl" (language), "z" (zoom), "t" (map type), "om", (overview map), "iwloc" (display info bubble), "ll" (lat,lng). Friendly names of "display_info" (iwloc), "map_type" (t), and "overview" (om) can be used. (optional)
+	* @access   public
+	* @param    mixed	address can be either an array with "address", "city", "state" or simply a string. You can also pass lat and lng values as an array
+	* @param    array	additional map parameters that include "hl" (language), "z" (zoom), "t" (map type), "om", (overview map), "iwloc" (display info bubble), "ll" (lat,lng). Friendly names of "display_info" (iwloc), "map_type" (t), and "overview" (om) can be used. (optional)
 	* @return   string
 	*/
 	function google_map_url($address, $params = array())
@@ -342,10 +342,11 @@ if (!function_exists('google_geolocate'))
 	* Use sleep() or usleep() functions to meter multiple requests (10/s is limit I believe)
 	* More on the return types here: https://developers.google.com/maps/documentation/geocoding/
 	*
-	* @access    public
-	* @param    mixed	Address can be either an array with "address", "city", "state" or simply a string
-	* @param    mixed	Return type can be 'all' (default), 'address_components', 'formatted_address', 'geometry', 'location', 'street_number', 'route', 'neighborhood', 'city',  'county', 'state', 'country', 'zip' (optional)
-	* @return   mixed  usually an array (e.g. array('latitude' => xxxx, 'longitude' => xxxx))
+	* @access   public
+	* @param    mixed	address can be either an array with "address", "city", "state" or simply a string
+	* @param    mixed	return type can be 'all' (default), 'address_components', 'formatted_address', 'geometry', 'location', 'street_number', 'route', 'neighborhood', 'city',  'county', 'state', 'country', 'zip' (optional)
+	* @param    bool    whether to return value under 'short_name' or 'long_name' if defined in result
+	* @return   mixed   usually an array (e.g. array('latitude' => xxxx, 'longitude' => xxxx))
 	*/
 	function google_geolocate($data, $return = 'all', $long = TRUE)
 	{

--- a/fuel/modules/fuel/helpers/scraper_helper.php
+++ b/fuel/modules/fuel/helpers/scraper_helper.php
@@ -26,7 +26,6 @@
  * @link		http://docs.getfuelcms.com/helpers/scraper_helper
  */
 
-
 // --------------------------------------------------------------------
 
 if (!function_exists('scrape_html'))
@@ -131,5 +130,6 @@ if (!function_exists('is_valid_page'))
 		return $CI->curl->is_valid($url);
 	}
 }
+
 /* End of file scraper_helper.php */
 /* Location: ./modules/fuel/helpers/scraper_helper.php */

--- a/fuel/modules/fuel/helpers/scraper_helper.php
+++ b/fuel/modules/fuel/helpers/scraper_helper.php
@@ -29,17 +29,17 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Uses <a href="[user_guide_url]libraries/curl">CURL</a> to scrape the contents of a URL
- *
- * @access	public
- * @param	string	URL of page to scrape contents
- * @param	array	POST parameters to pass along in the request
- * @param	array	An additional set of CURL options
- * @return	string
- */	
 if (!function_exists('scrape_html'))
 {
+	/**
+	 * Uses <a href="[user_guide_url]libraries/curl">CURL</a> to scrape the contents of a URL
+	 *
+	 * @access	public
+	 * @param	string	URL of page to scrape contents
+	 * @param	array	POST parameters to pass along in the request
+	 * @param	array	An additional set of CURL options
+	 * @return	string
+	 */
 	function scrape_html($url, $post = array(), $opts = array())
 	{
 		$CI =& get_instance();
@@ -68,16 +68,16 @@ if (!function_exists('scrape_html'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a DOM object of a page or a result object if an XPath query was passed
- *
- * @access	public
- * @param	string	URL of page to scrape contents
- * @param	string	an XPath query to pass
- * @return	object
- */	
 if (!function_exists('scrape_dom'))
 {
+	/**
+	 * Returns a DOM object of a page or a result object if an XPath query was passed
+	 *
+	 * @access	public
+	 * @param	string	URL of page to scrape contents
+	 * @param	string	an XPath query to pass
+	 * @return	object
+	 */
 	function scrape_dom($url, $xpath_query = NULL)
 	{
 		if (is_http_path($url))
@@ -115,15 +115,15 @@ if (!function_exists('scrape_dom'))
 
 // --------------------------------------------------------------------
 
-/**
- * Uses <a href="[user_guide_url]libraries/curl">CURL</a> to determine if a page exists or not
- *
- * @access	public
- * @param	string	URL of page to check
- * @return	boolean
- */	
 if (!function_exists('is_valid_page'))
 {
+	/**
+	 * Uses <a href="[user_guide_url]libraries/curl">CURL</a> to determine if a page exists or not
+	 *
+	 * @access	public
+	 * @param	string	URL of page to check
+	 * @return	boolean
+	 */
 	function is_valid_page($url)
 	{
 		$CI =& get_instance();

--- a/fuel/modules/fuel/helpers/session_helper.php
+++ b/fuel/modules/fuel/helpers/session_helper.php
@@ -102,7 +102,7 @@ if (!function_exists('session_set_flashdata'))
 	 *
 	 * @access	public
 	 * @param	string	variable name
-	 * @param   string  value
+	 * @param	string	value
 	 * @return	boolean
 	 */
 	function session_set_flashdata($key, $value)

--- a/fuel/modules/fuel/helpers/session_helper.php
+++ b/fuel/modules/fuel/helpers/session_helper.php
@@ -102,6 +102,7 @@ if (!function_exists('session_set_flashdata'))
 	 *
 	 * @access	public
 	 * @param	string	variable name
+	 * @param   string  value
 	 * @return	boolean
 	 */
 	function session_set_flashdata($key, $value)

--- a/fuel/modules/fuel/helpers/session_helper.php
+++ b/fuel/modules/fuel/helpers/session_helper.php
@@ -26,7 +26,6 @@
  * @link		http://docs.getfuelcms.com/helpers/session_helper
  */
 
-
 // --------------------------------------------------------------------
 
 if (!function_exists('session_userdata'))
@@ -70,6 +69,7 @@ if (!function_exists('session_set_userdata'))
 		return $CI->session->set_userdata($key, $value);
 	}
 }
+
 // --------------------------------------------------------------------
 
 if (!function_exists('session_flashdata'))
@@ -114,5 +114,6 @@ if (!function_exists('session_set_flashdata'))
 		return $CI->session->set_flashdata($key, $value);
 	}
 }
+
 /* End of file session_helper.php */
 /* Location: ./modules/fuel/helpers/session_helper.php */

--- a/fuel/modules/fuel/helpers/session_helper.php
+++ b/fuel/modules/fuel/helpers/session_helper.php
@@ -29,16 +29,15 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Returns a session variable
- *
- * @access	public
- * @param	string	variable name
- * @return	boolean
- */	
-
 if (!function_exists('session_userdata'))
 {
+	/**
+	 * Returns a session variable
+	 *
+	 * @access	public
+	 * @param	string	variable name
+	 * @return	boolean
+	 */
 	function session_userdata($key)
 	{
 		$CI =& get_instance();
@@ -52,15 +51,15 @@ if (!function_exists('session_userdata'))
 
 // --------------------------------------------------------------------
 
-/**
- * Sets a session variable
- *
- * @access	public
- * @param	string	variable name
- * @return	boolean
- */	
 if (!function_exists('session_set_userdata'))
 {
+	/**
+	 * Sets a session variable
+	 *
+	 * @access	public
+	 * @param	string	variable name
+	 * @return	boolean
+	 */
 	function session_set_userdata($key, $value)
 	{
 		$CI =& get_instance();
@@ -73,15 +72,15 @@ if (!function_exists('session_set_userdata'))
 }
 // --------------------------------------------------------------------
 
-/**
- * Returns a session flash variable
- *
- * @access	public
- * @param	string	variable name
- * @return	boolean
- */	
 if (!function_exists('session_flashdata'))
 {
+	/**
+	 * Returns a session flash variable
+	 *
+	 * @access	public
+	 * @param	string	variable name
+	 * @return	boolean
+	 */
 	function session_flashdata($key)
 	{
 		$CI =& get_instance();
@@ -96,15 +95,15 @@ if (!function_exists('session_flashdata'))
 
 // --------------------------------------------------------------------
 
-/**
- * Sets a session flash variable
- *
- * @access	public
- * @param	string	variable name
- * @return	boolean
- */	
 if (!function_exists('session_set_flashdata'))
 {
+	/**
+	 * Sets a session flash variable
+	 *
+	 * @access	public
+	 * @param	string	variable name
+	 * @return	boolean
+	 */
 	function session_set_flashdata($key, $value)
 	{
 		$CI =& get_instance();

--- a/fuel/modules/fuel/helpers/simplepie_helper.php
+++ b/fuel/modules/fuel/helpers/simplepie_helper.php
@@ -35,8 +35,8 @@ if (!function_exists('simplepie'))
 	 *
 	 * @access	public
 	 * @param	string	Feed URL
-	 * @param	string	The number of results to return
-	 * @param	string	Additional parameters which include, cache_duration, enable_order_by_date, enable_cache and cache_location
+	 * @param	int		The number of results to return
+	 * @param	array	Additional parameters which include, cache_duration, enable_order_by_date, enable_cache and cache_location
 	 * @return	object
 	 */
 	function simplepie($feed, $limit = 5, $params = array())

--- a/fuel/modules/fuel/helpers/simplepie_helper.php
+++ b/fuel/modules/fuel/helpers/simplepie_helper.php
@@ -29,17 +29,17 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Uses <a href="[user_guide_url]libraries/simplepie">SimplePie</a> class to retrieve an RSS Feed
- *
- * @access	public
- * @param	string	Feed URL
- * @param	string	The number of results to return
- * @param	string	Additional parameters which include, cache_duration, enable_order_by_date, enable_cache and cache_location
- * @return	object
- */
 if (!function_exists('simplepie'))
 {
+	/**
+	 * Uses <a href="[user_guide_url]libraries/simplepie">SimplePie</a> class to retrieve an RSS Feed
+	 *
+	 * @access	public
+	 * @param	string	Feed URL
+	 * @param	string	The number of results to return
+	 * @param	string	Additional parameters which include, cache_duration, enable_order_by_date, enable_cache and cache_location
+	 * @return	object
+	 */
 	function simplepie($feed, $limit = 5, $params = array())
 	{
 		$CI =& get_instance();

--- a/fuel/modules/fuel/helpers/simplepie_helper.php
+++ b/fuel/modules/fuel/helpers/simplepie_helper.php
@@ -26,7 +26,6 @@
  * @link		http://docs.getfuelcms.com/helpers/simplepie_helper
  */
 
-
 // --------------------------------------------------------------------
 
 if (!function_exists('simplepie'))

--- a/fuel/modules/fuel/helpers/social_helper.php
+++ b/fuel/modules/fuel/helpers/social_helper.php
@@ -29,16 +29,16 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Uses <a href="../libraries/social">Social</a> class's share method to return social links
- *
- * @access	public
- * @param	string	The type of social URL. A list of supported URLs can be found in the fuel/application/config/social.php file under the $config['share_url']
- * @param	mixed	Can be an object or an array of values
- * @return	string
- */
 if (!function_exists('share'))
 {
+	/**
+	 * Uses <a href="../libraries/social">Social</a> class's share method to return social links
+	 *
+	 * @access	public
+	 * @param	string	The type of social URL. A list of supported URLs can be found in the fuel/application/config/social.php file under the $config['share_url']
+	 * @param	mixed	Can be an object or an array of values
+	 * @return	string
+	 */
 	function share($type, $values = NULL)
 	{
 		$CI =& get_instance();
@@ -50,15 +50,15 @@ if (!function_exists('share'))
 	}
 }
 
-/**
- * Uses <a href="../libraries/social">Social</a> class's og method to create open graph links
- *
- * @access	public
- * @param	array	An array of values for the open graph which can include array keys of 'title', 'url', 'description', 'image', 'site_name', 'type'
- * @return	string
- */
 if (!function_exists('og'))
 {
+	/**
+	 * Uses <a href="../libraries/social">Social</a> class's og method to create open graph links
+	 *
+	 * @access	public
+	 * @param	array	An array of values for the open graph which can include array keys of 'title', 'url', 'description', 'image', 'site_name', 'type'
+	 * @return	string
+	 */
 	function og($values)
 	{
 		$CI =& get_instance();
@@ -70,17 +70,17 @@ if (!function_exists('og'))
 	}
 }
 
-/**
- * Creates the popup window javascript for the share links and writes the javascript only once to the page.
- *
- * @access	public
- * @param	int		The width of the popup javascript window (optional)
- * @param	int		The height of the popup javascript window (optional)
- * @param	string	The selector used for the popup window. Default is .popup (optional)
- * @return	string
- */
 if (!function_exists('social_popup_js'))
 {
+	/**
+	 * Creates the popup window javascript for the share links and writes the javascript only once to the page.
+	 *
+	 * @access	public
+	 * @param	int		The width of the popup javascript window (optional)
+	 * @param	int		The height of the popup javascript window (optional)
+	 * @param	string	The selector used for the popup window. Default is .popup (optional)
+	 * @return	string
+	 */
 	function social_popup_js($width = 640, $height = 500, $selector = 'popup')
 	{
 		// only write the javascript one time so we create a static variable

--- a/fuel/modules/fuel/helpers/social_helper.php
+++ b/fuel/modules/fuel/helpers/social_helper.php
@@ -26,7 +26,6 @@
  * @link		http://docs.getfuelcms.com/helpers/social_helper
  */
 
-
 // --------------------------------------------------------------------
 
 if (!function_exists('share'))
@@ -50,6 +49,8 @@ if (!function_exists('share'))
 	}
 }
 
+// --------------------------------------------------------------------
+
 if (!function_exists('og'))
 {
 	/**
@@ -69,6 +70,8 @@ if (!function_exists('og'))
 		return $CI->social->og($values);
 	}
 }
+
+// --------------------------------------------------------------------
 
 if (!function_exists('social_popup_js'))
 {

--- a/fuel/modules/fuel/helpers/utility_helper.php
+++ b/fuel/modules/fuel/helpers/utility_helper.php
@@ -48,15 +48,15 @@ if (!function_exists('CI'))
 
 // --------------------------------------------------------------------
 
-/**
- * Capture content via an output buffer
- *
- * @param	boolean	turn on output buffering
- * @param	string	if set to 'all', will clear end the buffer and clean it
- * @return 	string	return buffered content
- */
 if (!function_exists('capture'))
 {
+	/**
+	 * Capture content via an output buffer
+	 *
+	 * @param	boolean	turn on output buffering
+	 * @param	string	if set to 'all', will clear end the buffer and clean it
+	 * @return 	string	return buffered content
+	 */
 	function capture($on = TRUE, $clean = 'all')
 	{
 		$str = '';
@@ -85,14 +85,14 @@ if (!function_exists('capture'))
 
 // --------------------------------------------------------------------
 
-/**
- * Format true value
- *
- * @param	mixed	possible true value
- * @return 	string	formatted true value
- */
 if (!function_exists('is_true_val'))
 {
+	/**
+	 * Format true value
+	 *
+	 * @param	mixed	possible true value
+	 * @return 	string	formatted true value
+	 */
 	function is_true_val($val)
 	{
 		$val = strtolower($val);
@@ -102,14 +102,14 @@ if (!function_exists('is_true_val'))
 
 // --------------------------------------------------------------------
 
-/**
- * Boolean check to determine string content is serialized
- *
- * @param	mixed	possible serialized string
- * @return 	boolean
- */
 if (!function_exists('is_serialized_str'))
 {
+	/**
+	 * Boolean check to determine string content is serialized
+	 *
+	 * @param	mixed	possible serialized string
+	 * @return 	boolean
+	 */
 	function is_serialized_str($data)
 	{
 		if ( !is_string($data))
@@ -139,14 +139,14 @@ if (!function_exists('is_serialized_str'))
 
 // --------------------------------------------------------------------
 
-/**
- * Boolean check to determine string content is a JSON object string
- *
- * @param	mixed	possible serialized string
- * @return 	boolean
- */
 if (!function_exists('is_json_str'))
 {
+	/**
+	 * Boolean check to determine string content is a JSON object string
+	 *
+	 * @param	mixed	possible serialized string
+	 * @return 	boolean
+	 */
 	function is_json_str($data)
 	{
 		if (is_string($data))
@@ -160,15 +160,15 @@ if (!function_exists('is_json_str'))
 
 // --------------------------------------------------------------------
 
-/**
- * Print object in human-readible format
- * 
- * @param	mixed	The variable to dump
- * @param	boolean	Return string
- * @return 	string
- */
 if (!function_exists('print_obj'))
 {
+	/**
+	 * Print object in human-readible format
+	 *
+	 * @param	mixed	The variable to dump
+	 * @param	boolean	Return string
+	 * @return 	string
+	 */
 	function print_obj($obj, $return = FALSE)
 	{
 		$str = "<pre>";
@@ -207,14 +207,14 @@ if (!function_exists('print_obj'))
 
 // --------------------------------------------------------------------
 
-/**
- * Logs an error message to logs file
- *
- * @param	string	Error message
- * @return 	void
- */
 if (!function_exists('log_error'))
 {
+	/**
+	 * Logs an error message to logs file
+	 *
+	 * @param	string	Error message
+	 * @return 	void
+	 */
 	function log_error($error) 
 	{
 		log_message('error', $error);
@@ -223,13 +223,13 @@ if (!function_exists('log_error'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns whether the current environment is set for development
- *
- * @return 	boolean
- */
 if (!function_exists('is_dev_mode'))
 {
+	/**
+	 * Returns whether the current environment is set for development
+	 *
+	 * @return 	boolean
+	 */
 	function is_dev_mode()
 	{
 		return (ENVIRONMENT != 'production');
@@ -238,13 +238,13 @@ if (!function_exists('is_dev_mode'))
 
 // --------------------------------------------------------------------
 
-/**
- * Returns whether the current environment is equal to the passed environment
- *
- * @return 	boolean
- */
 if (!function_exists('is_environment'))
 {
+	/**
+	 * Returns whether the current environment is equal to the passed environment
+	 *
+	 * @return 	boolean
+	 */
 	function is_environment($environment)
 	{
 		return (strtolower(ENVIRONMENT) == strtolower($environment));

--- a/fuel/modules/fuel/helpers/utility_helper.php
+++ b/fuel/modules/fuel/helpers/utility_helper.php
@@ -34,7 +34,7 @@
 /**
  * Returns the global CI object
  *
- * @return 	object
+ * @return	object
  */
 if (!function_exists('CI'))
 {
@@ -55,7 +55,7 @@ if (!function_exists('capture'))
 	 *
 	 * @param	boolean	turn on output buffering
 	 * @param	string	if set to 'all', will clear end the buffer and clean it
-	 * @return 	string	return buffered content
+	 * @return	string	return buffered content
 	 */
 	function capture($on = TRUE, $clean = 'all')
 	{
@@ -91,7 +91,7 @@ if (!function_exists('is_true_val'))
 	 * Format true value
 	 *
 	 * @param	mixed	possible true value
-	 * @return 	string	formatted true value
+	 * @return	string	formatted true value
 	 */
 	function is_true_val($val)
 	{
@@ -108,7 +108,7 @@ if (!function_exists('is_serialized_str'))
 	 * Boolean check to determine string content is serialized
 	 *
 	 * @param	mixed	possible serialized string
-	 * @return 	boolean
+	 * @return	boolean
 	 */
 	function is_serialized_str($data)
 	{
@@ -145,7 +145,7 @@ if (!function_exists('is_json_str'))
 	 * Boolean check to determine string content is a JSON object string
 	 *
 	 * @param	mixed	possible serialized string
-	 * @return 	boolean
+	 * @return	boolean
 	 */
 	function is_json_str($data)
 	{
@@ -167,7 +167,7 @@ if (!function_exists('print_obj'))
 	 *
 	 * @param	mixed	The variable to dump
 	 * @param	boolean	Return string
-	 * @return 	string
+	 * @return	string
 	 */
 	function print_obj($obj, $return = FALSE)
 	{
@@ -213,7 +213,7 @@ if (!function_exists('log_error'))
 	 * Logs an error message to logs file
 	 *
 	 * @param	string	Error message
-	 * @return 	void
+	 * @return	void
 	 */
 	function log_error($error) 
 	{
@@ -228,7 +228,7 @@ if (!function_exists('is_dev_mode'))
 	/**
 	 * Returns whether the current environment is set for development
 	 *
-	 * @return 	boolean
+	 * @return	boolean
 	 */
 	function is_dev_mode()
 	{
@@ -243,9 +243,9 @@ if (!function_exists('is_environment'))
 	/**
 	 * Returns whether the current environment is equal to the passed environment
 	 *
-	 * @access  public
-	 * @param   string   environment to test
-	 * @return 	boolean
+	 * @access	public
+	 * @param	string	environment to test
+	 * @return	boolean
 	 */
 	function is_environment($environment)
 	{

--- a/fuel/modules/fuel/helpers/utility_helper.php
+++ b/fuel/modules/fuel/helpers/utility_helper.php
@@ -243,6 +243,8 @@ if (!function_exists('is_environment'))
 	/**
 	 * Returns whether the current environment is equal to the passed environment
 	 *
+	 * @access  public
+	 * @param   string   environment to test
 	 * @return 	boolean
 	 */
 	function is_environment($environment)

--- a/fuel/modules/fuel/helpers/validator_helper.php
+++ b/fuel/modules/fuel/helpers/validator_helper.php
@@ -142,7 +142,7 @@ if (!function_exists('min_num'))
 	 *
 	 * @access	public
 	 * @param	int		integer of any length
-	 * @param 	int		integer of any length to test against
+	 * @param	int		integer of any length to test against
 	 * @return	boolean
 	 */
 	function min_num($var, $limit = 1)
@@ -164,7 +164,7 @@ if (!function_exists('max_num'))
 	 *
 	 * @access	public
 	 * @param	int		integer of any length
-	 * @param 	int		integer of any length to test against
+	 * @param	int		integer of any length to test against
 	 * @return	boolean
 	 */
 	function max_num($var, $limit = 1)
@@ -186,8 +186,8 @@ if (!function_exists('is_between'))
 	 *
 	 * @access	public
 	 * @param	int		integer of any length
-	 * @param 	int		integer of any length to test low
-	 * @param 	int		integer of any length to test high
+	 * @param	int		integer of any length to test low
+	 * @param	int		integer of any length to test high
 	 * @return	boolean
 	 */
 	function is_between($var, $lo, $hi)
@@ -209,8 +209,8 @@ if (!function_exists('is_outside'))
 	 *
 	 * @access	public
 	 * @param	int		integer of any length
-	 * @param 	int		integer of any length to test low
-	 * @param 	int		integer of any length to test high
+	 * @param	int		integer of any length to test low
+	 * @param	int		integer of any length to test high
 	 * @return	boolean
 	 */
 	function is_outside($var, $lo, $hi)
@@ -232,7 +232,7 @@ if (!function_exists('length_max'))
 	 *
 	 * @access	public
 	 * @param	string	string of any length
-	 * @param 	int		integer to test string length against
+	 * @param	int		integer to test string length against
 	 * @return	boolean
 	 */
 	function length_max($str, $limit = 1000)
@@ -257,7 +257,7 @@ if (!function_exists('length_min'))
 	 *
 	 * @access	public
 	 * @param	string	string of any length
-	 * @param 	int		integer to test string length against
+	 * @param	int		integer to test string length against
 	 * @return	boolean
 	 */
 	function length_min($str, $limit = 1)
@@ -798,7 +798,7 @@ if (!function_exists('display_errors'))
 	 * Display user-defined errors via javascript and html
 	 *
 	 * @access	public
-	 * @param	string  css class to define error styling
+	 * @param	string	css class to define error styling
 	 * @param	mixed	collection of errors created by user
 	 * @return	string
 	 */
@@ -876,8 +876,8 @@ if (!function_exists('add_error'))
 	 * Add a user-defined error message
 	 *
 	 * @access	public
-	 * @param	string error message
-	 * @param	string key value for error message array
+	 * @param	string	error message
+	 * @param	string	key value for error message array
 	 * @return	void
 	 */
 	function add_error($msg, $key = NULL)
@@ -901,8 +901,8 @@ if (!function_exists('add_errors'))
 	 * Add a user-defined error message
 	 *
 	 * @access	public
-	 * @param	string error message
-	 * @param	string key value for error message array
+	 * @param	string	error message
+	 * @param	string	key value for error message array
 	 * @return	void
 	 */
 	function add_errors($errors)
@@ -923,7 +923,7 @@ if (!function_exists('get_error'))
 	 * Get a user-defined error message
 	 *
 	 * @access	public
-	 * @param	string key value for error message array
+	 * @param	string	key value for error message array
 	 * @return	string
 	 */
 	function get_error($key = null)

--- a/fuel/modules/fuel/helpers/validator_helper.php
+++ b/fuel/modules/fuel/helpers/validator_helper.php
@@ -878,11 +878,11 @@ if (!function_exists('add_error'))
 	 * @access	public
 	 * @param	string error message
 	 * @param	string key value for error message array
-	 * @return	boolean
+	 * @return	void
 	 */
 	function add_error($msg, $key = NULL)
 	{
-		if(defined('GLOBAL_ERRORS')) 
+		if(defined('GLOBAL_ERRORS'))
 		{
 			if(empty($key)) 
 			{
@@ -903,7 +903,7 @@ if (!function_exists('add_errors'))
 	 * @access	public
 	 * @param	string error message
 	 * @param	string key value for error message array
-	 * @return	boolean
+	 * @return	void
 	 */
 	function add_errors($errors)
 	{

--- a/fuel/modules/fuel/helpers/validator_helper.php
+++ b/fuel/modules/fuel/helpers/validator_helper.php
@@ -31,15 +31,15 @@
 
 // --------------------------------------------------------------------
 
-/**
- * Check for variable solvency
- *
- * @access	public
- * @param	mixed	variable of any kind
- * @return	boolean
- */
 if (!function_exists('required'))
 {
+	/**
+	 * Check for variable solvency
+	 *
+	 * @access	public
+	 * @param	mixed	variable of any kind
+	 * @return	boolean
+	 */
 	function required($var)
 	{
 		if (is_string($var))
@@ -65,16 +65,16 @@ if (!function_exists('required'))
 
 // --------------------------------------------------------------------
 
-/**
- * Check for matches within a string
- *
- * @access	public
- * @param	string	string containing content to be matched against
- * @param	string	regular expression (delimiters excluded)
- * @return	boolean
- */
 if (!function_exists('regex'))
 {
+	/**
+	 * Check for matches within a string
+	 *
+	 * @access	public
+	 * @param	string	string containing content to be matched against
+	 * @param	string	regular expression (delimiters excluded)
+	 * @return	boolean
+	 */
 	function regex($var = null, $regex)
 	{
 		return preg_match('#'.$regex.'#', $var);
@@ -83,15 +83,15 @@ if (!function_exists('regex'))
 
 // --------------------------------------------------------------------
 
-/**
- * Ensure at least one array variable contains content
- *
- * @access	public
- * @param	array	array containing values of indiscriminate size
- * @return	boolean
- */
 if (!function_exists('has_one_of_these'))
 {
+	/**
+	 * Ensure at least one array variable contains content
+	 *
+	 * @access	public
+	 * @param	array	array containing values of indiscriminate size
+	 * @return	boolean
+	 */
 	function has_one_of_these($args = null)
 	{
 		if(!is_array($args))
@@ -111,16 +111,16 @@ if (!function_exists('has_one_of_these'))
 
 // --------------------------------------------------------------------
 
-/**
- * Validate email address against standard email address form
- *
- * @access	public
- * @param	string	string containing email address
- * @return	boolean
- */
 // to prevent issue with email helpers function
 if ( ! function_exists('valid_email'))
 {
+	/**
+	 * Validate email address against standard email address form
+	 *
+	 * @access	public
+	 * @param	string	string containing email address
+	 * @return	boolean
+	 */
 	function valid_email($email)
 	{
 		if (function_exists('filter_var'))
@@ -135,16 +135,16 @@ if ( ! function_exists('valid_email'))
 } 
 // --------------------------------------------------------------------
 
-/**
- * Ensure a numeric value is greater than given size
- *
- * @access	public
- * @param	int		integer of any length
- * @param 	int		integer of any length to test against 
- * @return	boolean
- */
 if (!function_exists('min_num'))
 {
+	/**
+	 * Ensure a numeric value is greater than given size
+	 *
+	 * @access	public
+	 * @param	int		integer of any length
+	 * @param 	int		integer of any length to test against
+	 * @return	boolean
+	 */
 	function min_num($var, $limit = 1)
 	{
 		if($var < $limit)
@@ -157,16 +157,16 @@ if (!function_exists('min_num'))
 
 // --------------------------------------------------------------------
 
-/**
- * Ensure a numeric value is less than given size
- *
- * @access	public
- * @param	int		integer of any length
- * @param 	int		integer of any length to test against 
- * @return	boolean
- */
 if (!function_exists('max_num'))
 {
+	/**
+	 * Ensure a numeric value is less than given size
+	 *
+	 * @access	public
+	 * @param	int		integer of any length
+	 * @param 	int		integer of any length to test against
+	 * @return	boolean
+	 */
 	function max_num($var, $limit = 1)
 	{
 		if($var > $limit)
@@ -179,17 +179,17 @@ if (!function_exists('max_num'))
 
 // --------------------------------------------------------------------
 
-/**
- * Ensure a numeric value exists between a given size
- *
- * @access	public
- * @param	int		integer of any length
- * @param 	int		integer of any length to test low
- * @param 	int		integer of any length to test high 
- * @return	boolean
- */
 if (!function_exists('is_between'))
 {
+	/**
+	 * Ensure a numeric value exists between a given size
+	 *
+	 * @access	public
+	 * @param	int		integer of any length
+	 * @param 	int		integer of any length to test low
+	 * @param 	int		integer of any length to test high
+	 * @return	boolean
+	 */
 	function is_between($var, $lo, $hi)
 	{
 		if($var <= $hi AND $var >= $lo)
@@ -202,17 +202,17 @@ if (!function_exists('is_between'))
 
 // --------------------------------------------------------------------
 
-/**
- * Ensure a numeric value exists outside a given range
- *
- * @access	public
- * @param	int		integer of any length
- * @param 	int		integer of any length to test low
- * @param 	int		integer of any length to test high 
- * @return	boolean
- */
 if (!function_exists('is_outside'))
 {
+	/**
+	 * Ensure a numeric value exists outside a given range
+	 *
+	 * @access	public
+	 * @param	int		integer of any length
+	 * @param 	int		integer of any length to test low
+	 * @param 	int		integer of any length to test high
+	 * @return	boolean
+	 */
 	function is_outside($var, $lo, $hi)
 	{
 		if($var >= $hi AND $var <= $lo)
@@ -225,16 +225,16 @@ if (!function_exists('is_outside'))
 
 // --------------------------------------------------------------------
 
-/**
- * Ensure a string's size exists within a certain limited range
- *
- * @access	public
- * @param	string	string of any length
- * @param 	int		integer to test string length against
- * @return	boolean
- */
 if (!function_exists('length_max'))
 {
+	/**
+	 * Ensure a string's size exists within a certain limited range
+	 *
+	 * @access	public
+	 * @param	string	string of any length
+	 * @param 	int		integer to test string length against
+	 * @return	boolean
+	 */
 	function length_max($str, $limit = 1000)
 	{
 		if (strlen(strval($str)) > $limit)
@@ -250,16 +250,16 @@ if (!function_exists('length_max'))
 
 // --------------------------------------------------------------------
 
-/**
- * Ensure a string exists within a given limit
- *
- * @access	public
- * @param	string	string of any length
- * @param 	int		integer to test string length against
- * @return	boolean
- */
 if (!function_exists('length_min'))
 {
+	/**
+	 * Ensure a string exists within a given limit
+	 *
+	 * @access	public
+	 * @param	string	string of any length
+	 * @param 	int		integer to test string length against
+	 * @return	boolean
+	 */
 	function length_min($str, $limit = 1)
 	{
 		if (strlen(strval($str)) < $limit)
@@ -274,15 +274,15 @@ if (!function_exists('length_min'))
 }
 // --------------------------------------------------------------------
 
-/**
- * Ensure a valid phone number
- *
- * @access	public
- * @param	string	string of any length
- * @return	boolean
- */
 if (!function_exists('valid_phone'))
 {
+	/**
+	 * Ensure a valid phone number
+	 *
+	 * @access	public
+	 * @param	string	string of any length
+	 * @return	boolean
+	 */
 	function valid_phone($str)
 	{
 		$num = $str;
@@ -304,16 +304,16 @@ if (!function_exists('valid_phone'))
 
 // --------------------------------------------------------------------
 
-/**
- * Ensure to variables are equal
- *
- * @access	public
- * @param	mixed	mixed variable to test equality
- * @param	mixed	mixed variable to test equality
- * @return	boolean
- */
 if (!function_exists('is_equal_to'))
 {
+	/**
+	 * Ensure to variables are equal
+	 *
+	 * @access	public
+	 * @param	mixed	mixed variable to test equality
+	 * @param	mixed	mixed variable to test equality
+	 * @return	boolean
+	 */
 	function is_equal_to($val, $val2)
 	{
 		if($val == $val2) 
@@ -327,16 +327,16 @@ if (!function_exists('is_equal_to'))
 
 // --------------------------------------------------------------------
 
-/**
- * Ensure to variables are not equal
- *
- * @access	public
- * @param	mixed	mixed variable to test equality
- * @param	mixed	mixed variable to test equality
- * @return	boolean
- */
 if (!function_exists('is_not_equal_to'))
 {
+	/**
+	 * Ensure to variables are not equal
+	 *
+	 * @access	public
+	 * @param	mixed	mixed variable to test equality
+	 * @param	mixed	mixed variable to test equality
+	 * @return	boolean
+	 */
 	function is_not_equal_to($val, $val2)
 	{
 		if($val != $val2) 
@@ -350,16 +350,16 @@ if (!function_exists('is_not_equal_to'))
 
 // --------------------------------------------------------------------
 
-/**
- * Test array to see if value exists
- *
- * @access	public
- * @param	mixed	mixed variable
- * @param	array	array to test if value exists
- * @return	boolean
- */
 if (!function_exists('is_one_of_these'))
 {
+	/**
+	 * Test array to see if value exists
+	 *
+	 * @access	public
+	 * @param	mixed	mixed variable
+	 * @param	array	array to test if value exists
+	 * @return	boolean
+	 */
 	function is_one_of_these($val, $search_in = array())
 	{
 		if (in_array($val, $search_in))
@@ -372,16 +372,16 @@ if (!function_exists('is_one_of_these'))
 
 // --------------------------------------------------------------------
 
-/**
- * Test array to see if value does not exist
- *
- * @access	public
- * @param	mixed	mixed variable
- * @param	array	array to test if value exists
- * @return	boolean
- */
 if (!function_exists('is_not_one_of_these'))
 {
+	/**
+	 * Test array to see if value does not exist
+	 *
+	 * @access	public
+	 * @param	mixed	mixed variable
+	 * @param	array	array to test if value exists
+	 * @return	boolean
+	 */
 	function is_not_one_of_these($val, $searchIn = array())
 	{
 		if(!in_array($val, $searchIn))
@@ -395,16 +395,16 @@ if (!function_exists('is_not_one_of_these'))
 
 // --------------------------------------------------------------------
 
-/**
- * Test array to see if a file is of a given type
- *
- * @access	public
- * @param	string	filename
- * @param	string	mime value of file to test
- * @return	boolean
- */
 if (!function_exists('is_of_file_type'))
 {
+	/**
+	 * Test array to see if a file is of a given type
+	 *
+	 * @access	public
+	 * @param	string	filename
+	 * @param	string	mime value of file to test
+	 * @return	boolean
+	 */
 	function is_of_file_type($fileName, $fileType)
 	{
 		if($fileType == 'zip') 
@@ -425,15 +425,15 @@ if (!function_exists('is_of_file_type'))
 
 // --------------------------------------------------------------------
 
-/**
- * Test array to see if a file is of a given type
- *
- * @access	public
- * @param	string	filename
- * @return	boolean
- */
 if (!function_exists('valid_file_upload'))
 {
+	/**
+	 * Test array to see if a file is of a given type
+	 *
+	 * @access	public
+	 * @param	string	filename
+	 * @return	boolean
+	 */
 	function valid_file_upload($file_name)
 	{
 		if(empty($_FILES[$file_name]) OR $_FILES[$file_name]['error'] > 0)
@@ -448,16 +448,16 @@ if (!function_exists('valid_file_upload'))
 
 // --------------------------------------------------------------------
 
-/**
- * Test string for valid characters
- *
- * @access	public
- * @param	mixed	string value
- * @param	array	list of allowed characters 
- * @return	boolean
- */
 if (!function_exists('is_safe_character'))
 {
+	/**
+	 * Test string for valid characters
+	 *
+	 * @access	public
+	 * @param	mixed	string value
+	 * @param	array	list of allowed characters
+	 * @return	boolean
+	 */
 	function is_safe_character($val, $allowed = array('_', '-'))
 	{
 		$newVal = str_replace($allowed, '', $val);
@@ -472,17 +472,17 @@ if (!function_exists('is_safe_character'))
 
 // --------------------------------------------------------------------
 
-/**
- * Test date and time for proper format
- *
- * @access	public
- * @param	string	date as string value
- * @param	string	format of date to test against
- * @param	string	delimiter of date value given for testing 
- * @return	boolean
- */
 if (!function_exists('valid_date_time'))
 {
+	/**
+	 * Test date and time for proper format
+	 *
+	 * @access	public
+	 * @param	string	date as string value
+	 * @param	string	format of date to test against
+	 * @param	string	delimiter of date value given for testing
+	 * @return	boolean
+	 */
 	function valid_date_time($date, $format = "ymd", $delimiter = "-") 
 	{
 		return (valid_date($date, $format, $delimiter) && valid_time($date));
@@ -491,17 +491,17 @@ if (!function_exists('valid_date_time'))
 
 // --------------------------------------------------------------------
 
-/**
- * Test date for proper format
- *
- * @access	public
- * @param	string	date as string value
- * @param	string	format of date to test against
- * @param	string	delimiter of date value given for testing 
- * @return	boolean
- */
 if (!function_exists('valid_date'))
 {
+	/**
+	 * Test date for proper format
+	 *
+	 * @access	public
+	 * @param	string	date as string value
+	 * @param	string	format of date to test against
+	 * @param	string	delimiter of date value given for testing
+	 * @return	boolean
+	 */
 	function valid_date($date, $format = "ymd", $delimiter = "-") 
 	{
 		list($d1, $d2, $d3) = sscanf($date, "%d".$delimiter."%d".$delimiter."%d");
@@ -515,15 +515,15 @@ if (!function_exists('valid_date'))
 
 // --------------------------------------------------------------------
 
-/**
- * Test time for proper format
- *
- * @access	public
- * @param	string	date as string value
- * @return	boolean
- */
 if (!function_exists('valid_time'))
 {
+	/**
+	 * Test time for proper format
+	 *
+	 * @access	public
+	 * @param	string	date as string value
+	 * @return	boolean
+	 */
 	function valid_time($date) 
 	{
 		$date = trim($date);
@@ -578,17 +578,17 @@ if (!function_exists('valid_time'))
 
 // --------------------------------------------------------------------
 
-/**
- * Validate date passed
- *
- * @access	public
- * @param	string	month value or current date value
- * @param	string	day value
- * @param	string	year value  
- * @return	boolean
- */
 if (!function_exists('valid_mdy'))
 {
+	/**
+	 * Validate date passed
+	 *
+	 * @access	public
+	 * @param	string	month value or current date value
+	 * @param	string	day value
+	 * @param	string	year value
+	 * @return	boolean
+	 */
 	function valid_mdy($m, $d = null, $y = null)
 	{
 		if(empty($d) && empty($y))
@@ -610,16 +610,16 @@ if (!function_exists('valid_mdy'))
 
 // --------------------------------------------------------------------
 
-/**
- * Check to dates to ensure one is after the other
- *
- * @access	public
- * @param	string	date value as string
- * @param	string	date value as string(should be later date)
- * @return	boolean
- */
 if (!function_exists('is_after_date'))
 {
+	/**
+	 * Check to dates to ensure one is after the other
+	 *
+	 * @access	public
+	 * @param	string	date value as string
+	 * @param	string	date value as string(should be later date)
+	 * @return	boolean
+	 */
 	function is_after_date($date1, $date2)
 	{
 		$date1 = strtotime($date1);
@@ -634,16 +634,16 @@ if (!function_exists('is_after_date'))
 
 // --------------------------------------------------------------------
 
-/**
- * Check to dates to ensure one is before the other
- *
- * @access	public
- * @param	string	date value as string(should be later date)
- * @param	string	date value as string
- * @return	boolean
- */
 if (!function_exists('is_before_date'))
 {
+	/**
+	 * Check to dates to ensure one is before the other
+	 *
+	 * @access	public
+	 * @param	string	date value as string(should be later date)
+	 * @param	string	date value as string
+	 * @return	boolean
+	 */
 	function is_before_date($date1, $date2)
 	{
 		$date1 = strtotime($date1);
@@ -658,17 +658,17 @@ if (!function_exists('is_before_date'))
 
 // --------------------------------------------------------------------
 
-/**
- * Check to validate date exists between two others
- *
- * @access	public
- * @param	string	date value as string
- * @param	string	date value as string(low date)
- * @param	string	date value as string(high date)
- * @return	boolean
- */
 if (!function_exists('is_between_dates'))
 {
+	/**
+	 * Check to validate date exists between two others
+	 *
+	 * @access	public
+	 * @param	string	date value as string
+	 * @param	string	date value as string(low date)
+	 * @param	string	date value as string(high date)
+	 * @return	boolean
+	 */
 	function is_between_dates($val, $date1, $date2)
 	{
 		$val = strtotime($val);
@@ -684,15 +684,15 @@ if (!function_exists('is_between_dates'))
 
 // --------------------------------------------------------------------
 
-/**
- * Check to see if date is a future date
- *
- * @access	public
- * @param	string	date value as string
- * @return	boolean
- */
 if (!function_exists('is_future_date'))
 {
+	/**
+	 * Check to see if date is a future date
+	 *
+	 * @access	public
+	 * @param	string	date value as string
+	 * @return	boolean
+	 */
 	function is_future_date($val)
 	{
 		return is_after_date($val, date("Y-m-d 00:00:00"));
@@ -701,15 +701,15 @@ if (!function_exists('is_future_date'))
 
 // --------------------------------------------------------------------
 
-/**
- * Check to see if date is past date
- *
- * @access	public
- * @param	string	date value as string
- * @return	boolean
- */
 if (!function_exists('is_past_date'))
 {
+	/**
+	 * Check to see if date is past date
+	 *
+	 * @access	public
+	 * @param	string	date value as string
+	 * @return	boolean
+	 */
 	function is_past_date($val)
 	{
 		return is_before_date($val, date("Y-m-d 23:59:59"));
@@ -718,15 +718,15 @@ if (!function_exists('is_past_date'))
 
 // --------------------------------------------------------------------
 
-/**
- * Display user-defined errors via javascript
- *
- * @access	public
- * @param	mixed	collection of errors created by user
- * @return	string
- */
 if (!function_exists('display_errors_js'))
 {
+	/**
+	 * Display user-defined errors via javascript
+	 *
+	 * @access	public
+	 * @param	mixed	collection of errors created by user
+	 * @return	string
+	 */
 	function display_errors_js($ERRORS = NULL) 
 	{
 		if (empty($GLOBALS['__ERRORS_JS__']))
@@ -791,16 +791,16 @@ if (!function_exists('display_errors_js'))
 
 // --------------------------------------------------------------------
 
-/**
- * Display user-defined errors via javascript and html
- *
- * @access	public
- * @param	string  css class to define error styling
- * @param	mixed	collection of errors created by user
- * @return	string
- */
 if (!function_exists('display_errors'))
 {
+	/**
+	 * Display user-defined errors via javascript and html
+	 *
+	 * @access	public
+	 * @param	string  css class to define error styling
+	 * @param	mixed	collection of errors created by user
+	 * @return	string
+	 */
 	function display_errors($ERRORS = NULL, $class = 'error')
 	{
 		$CI =& get_instance();
@@ -853,14 +853,14 @@ if (!function_exists('display_errors'))
 
 // --------------------------------------------------------------------
 
-/**
- * Check if any user defined errors have been defined
- *
- * @access	public
- * @return	boolean
- */
 if (!function_exists('has_errors'))
 {
+	/**
+	 * Check if any user defined errors have been defined
+	 *
+	 * @access	public
+	 * @return	boolean
+	 */
 	function has_errors()
 	{
 		return (defined('GLOBAL_ERRORS') && !empty($GLOBALS[GLOBAL_ERRORS]));
@@ -869,16 +869,16 @@ if (!function_exists('has_errors'))
 
 // --------------------------------------------------------------------
 
-/**
- * Add a user-defined error message
- *
- * @access	public
- * @param	string error message
- * @param	string key value for error message array
- * @return	boolean
- */
 if (!function_exists('add_error'))
 {
+	/**
+	 * Add a user-defined error message
+	 *
+	 * @access	public
+	 * @param	string error message
+	 * @param	string key value for error message array
+	 * @return	boolean
+	 */
 	function add_error($msg, $key = NULL)
 	{
 		if(defined('GLOBAL_ERRORS')) 
@@ -894,16 +894,16 @@ if (!function_exists('add_error'))
 
 // --------------------------------------------------------------------
 
-/**
- * Add a user-defined error message
- *
- * @access	public
- * @param	string error message
- * @param	string key value for error message array
- * @return	boolean
- */
 if (!function_exists('add_errors'))
 {
+	/**
+	 * Add a user-defined error message
+	 *
+	 * @access	public
+	 * @param	string error message
+	 * @param	string key value for error message array
+	 * @return	boolean
+	 */
 	function add_errors($errors)
 	{
 		$errors = (array) $errors;
@@ -915,15 +915,15 @@ if (!function_exists('add_errors'))
 }
 // --------------------------------------------------------------------
 
-/**
- * Get a user-defined error message
- *
- * @access	public
- * @param	string key value for error message array
- * @return	string
- */
 if (!function_exists('get_error'))
 {
+	/**
+	 * Get a user-defined error message
+	 *
+	 * @access	public
+	 * @param	string key value for error message array
+	 * @return	string
+	 */
 	function get_error($key = null)
 	{
 		if (defined('GLOBAL_ERRORS')) {
@@ -941,14 +941,14 @@ if (!function_exists('get_error'))
 
 // --------------------------------------------------------------------
 
-/**
- * Get all global error messages
- *
- * @access	public
- * @return	array
- */
 if (!function_exists('get_errors'))
 {
+	/**
+	 * Get all global error messages
+	 *
+	 * @access	public
+	 * @return	array
+	 */
 	function get_errors()
 	{
 		if (defined('GLOBAL_ERRORS') AND !empty($GLOBALS[GLOBAL_ERRORS]))

--- a/fuel/modules/fuel/helpers/validator_helper.php
+++ b/fuel/modules/fuel/helpers/validator_helper.php
@@ -28,7 +28,6 @@
  * @link		http://docs.getfuelcms.com/helpers/validator_helper
  */
 
-
 // --------------------------------------------------------------------
 
 if (!function_exists('required'))
@@ -133,6 +132,7 @@ if ( ! function_exists('valid_email'))
 		}
 	}
 } 
+
 // --------------------------------------------------------------------
 
 if (!function_exists('min_num'))
@@ -272,6 +272,7 @@ if (!function_exists('length_min'))
 		}
 	}
 }
+
 // --------------------------------------------------------------------
 
 if (!function_exists('valid_phone'))
@@ -913,6 +914,7 @@ if (!function_exists('add_errors'))
 		}
 	}
 }
+
 // --------------------------------------------------------------------
 
 if (!function_exists('get_error'))
@@ -958,5 +960,6 @@ if (!function_exists('get_errors'))
 		return NULL;
 	}
 }
+
 /* End of file validator_helper.php */
 /* Location: ./modules/fuel/helpers/validator_helper.php */


### PR DESCRIPTION
Moves the PHPDoc comments inside helper files so they appear inside the `if (!function_exists...)` checks.

This allows IDEs to link the PHPDocs to the functions. Developers can then be immediately notified by the IDE if they're using a helper function incorrectly (passing wrong parameters, etc).

Moreover, this helped me uncover some errors in the PHPDocs themselves.

Lastly, some missing delimiter comments `// -------` have been added.

Best to go through this MR commit by commit to better see what changed.