### PR TITLE
Fix several functions called with too many parameters

### DIFF
--- a/fuel/modules/fuel/libraries/Cli.php
+++ b/fuel/modules/fuel/libraries/Cli.php
@@ -96,7 +96,7 @@ class Cli
 	public function prompt($msg, $length = 4096)
 	{
 		$this->write($msg." ", FALSE);
-		$line = $this->input($length, $length);
+		$line = $this->input($length);
 		return trim($line); 
 	}
 

--- a/fuel/modules/fuel/libraries/Fuel_base_library.php
+++ b/fuel/modules/fuel/libraries/Fuel_base_library.php
@@ -50,7 +50,7 @@ class Fuel_base_library {
 	 * @param	array	config preferences
 	 * @return	void
 	 */	
-	public function __construct()
+	public function __construct($config = array())
 	{
 		$this->CI =& get_instance();
 		if (isset($this->CI->fuel))


### PR DESCRIPTION
The `input` function accepts two arguments, yet it's given two.