### PR TITLE
Fix 'asset_helper' not passing 'absolute' param to Asset library

### DIFF
--- a/fuel/modules/fuel/helpers/asset_helper.php
+++ b/fuel/modules/fuel/helpers/asset_helper.php
@@ -206,7 +206,7 @@ if (!function_exists('captcha_path'))
 	function captcha_path($file = NULL, $module = NULL, $absolute = NULL)
 	{
 		$CI = _get_assets();
-		return $CI->asset->captcha_path($file, $module);
+		return $CI->asset->captcha_path($file, $module, $absolute);
 	}
 }
 


### PR DESCRIPTION
Found another small bug in the `asset_helper`.

Test:

```php
$this->load->helper('asset');
var_dump(captcha_path('foo.txt', NULL, TRUE));
var_dump(captcha_path('foo.txt', NULL, FALSE));
```

Before:
```php
'/fuel-cms/assets/captchas/foo.txt'
'/fuel-cms/assets/captchas/foo.txt'
```
After:
```php
'http://localhost/fuel-cms/assets/captchas/foo.txt'
'/fuel-cms/assets/captchas/foo.txt'
```