### PR TITLE
Replace '-at-' with the '@' symbol in Git URLs when adding sub-modules

### DIFF
--- a/fuel/modules/fuel/controllers/Installer.php
+++ b/fuel/modules/fuel/controllers/Installer.php
@@ -84,7 +84,7 @@ class Installer extends Fuel_base_controller {
 
 		$uri = trim($this->uri->uri_string(), '/');
 		$uri = str_replace('-at-', '@', $uri);
-		$segs = explode('/', trim($this->uri->uri_string(), '/'));
+		$segs = explode('/', $uri);
 		$segs = array_slice($segs, 3);
 		$module = array_pop($segs);
 		$repo = implode('/', $segs);


### PR DESCRIPTION
The [documentation](http://docs.getfuelcms.com/modules) says:

> If your git repo path has a "@" in it, change it to a "-at-" or else you will get a "The URI you submitted has disallowed characters" error.

However this is not being done at the moment.