### PR TITLE
Fix PHP7 issues in Asset_test

### DIFF
--- a/fuel/modules/fuel/tests/Asset_test.php
+++ b/fuel/modules/fuel/tests/Asset_test.php
@@ -55,7 +55,7 @@ class Asset_test extends Tester_base {
 			$this->_reset($config);
 			$test = $this->CI->asset->{$t['func']}($t['file']);
 			$expected = 'http://'.$_SERVER['HTTP_HOST'].$p;
-			$this->run($test, $expected, 'Asset '.$t['func'].'() test 2');
+			$this->run($test, $expected, 'Asset '.$t['func'].'() test 3');
 		}
 	}
 	

--- a/fuel/modules/fuel/tests/Asset_test.php
+++ b/fuel/modules/fuel/tests/Asset_test.php
@@ -39,21 +39,21 @@ class Asset_test extends Tester_base {
 			$p = $expected = WEB_PATH.$this->init['assets_path'].$this->init['assets_folders'][$type].$t['file'];
 
 			// test 1 WITHOUT timestampe cache breaker
-			$test = $this->CI->asset->$t['func']($t['file']);
+			$test = $this->CI->asset->{$t['func']}($t['file']);
 			$expected = $p;
 			$this->run($test, $expected, 'Asset '.$t['func'].'() test 1');
 
 			// test 2 WITH timestampe cache breaker
 			$config = array('asset_append_cache_timestamp' => array($type));
 			$this->_reset($config);
-			$test = $this->CI->asset->$t['func']($t['file']);
+			$test = $this->CI->asset->{$t['func']}($t['file']);
 			$expected = $p.'?c='.strtotime($this->init['assets_last_updated']);
 			$this->run($test, $expected, 'Asset '.$t['func'].'() test 2');
 
 			// test 3 absolute path
 			$config = array('assets_absolute_path' => TRUE);
 			$this->_reset($config);
-			$test = $this->CI->asset->$t['func']($t['file']);
+			$test = $this->CI->asset->{$t['func']}($t['file']);
 			$expected = 'http://'.$_SERVER['HTTP_HOST'].$p;
 			$this->CI->unit->run($test, $expected, 'Asset '.$t['func'].'() test 2');
 		}

--- a/fuel/modules/fuel/tests/Asset_test.php
+++ b/fuel/modules/fuel/tests/Asset_test.php
@@ -55,7 +55,7 @@ class Asset_test extends Tester_base {
 			$this->_reset($config);
 			$test = $this->CI->asset->{$t['func']}($t['file']);
 			$expected = 'http://'.$_SERVER['HTTP_HOST'].$p;
-			$this->CI->unit->run($test, $expected, 'Asset '.$t['func'].'() test 2');
+			$this->run($test, $expected, 'Asset '.$t['func'].'() test 2');
 		}
 	}
 	


### PR DESCRIPTION
PHP 7.1.9.

Running tests in `Asset_test`, I get the following error:

```
Severity: Notice

Message: Array to string conversion

Filename: tests/Asset_test.php

Line Number: 42
```

This is documented in [the PHP manual](http://php.net/manual/en/migration70.incompatible.php), section "Changes to the handling of indirect variables, properties, and methods".

Other small issues:

- One of the tests didn't call `$this->run` meaning its name was formatted differently.
- That same test didn't report the correct test name.