### PR TITLE
Missing function "dir_files"

### DIFF
--- a/fuel/modules/fuel/libraries/Validator.php
+++ b/fuel/modules/fuel/libraries/Validator.php
@@ -293,7 +293,7 @@ class Validator {
 	 * Retrieve errors
 	 *
 	 * @access public
-	 * @return assoc array of errors and messages
+	 * @return array	assoc array of errors and messages
 	 */
 	public function get_errors()
 	{

--- a/fuel/modules/fuel/models/Fuel_assets_model.php
+++ b/fuel/modules/fuel/models/Fuel_assets_model.php
@@ -261,7 +261,7 @@ class Fuel_assets_model extends CI_Model {
 	{
 		$CI =& get_instance();
 		$assets_path = WEB_ROOT.$CI->config->item('assets_path').$dir.'/';
-		$files = dir_files($assets_path, false, false);
+		$files = $CI->fuel->assets->dir_files($assets_path, false, false);
 		return count($files);
 	}
 	

--- a/fuel/modules/fuel/models/Fuel_assets_model.php
+++ b/fuel/modules/fuel/models/Fuel_assets_model.php
@@ -64,7 +64,7 @@ class Fuel_assets_model extends CI_Model {
 	 *
 	 * @access	public
 	 * @param	array	Search filters
-	 * @return	void
+	 * @return	string
 	 */	
 	public function table_name()
 	{
@@ -99,10 +99,10 @@ class Fuel_assets_model extends CI_Model {
 	 *
 	 * @access	public
 	 * @param	int		limit
-	 * @param	string	offset
+	 * @param	int		offset
 	 * @param	string	column
 	 * @param	string	order
-	 * @return	array
+	 * @return	array|int
 	 */	
 	public function list_items($limit = null, $offset = 0, $col = 'name', $order = 'asc', $just_count = FALSE)
 	{
@@ -185,7 +185,6 @@ class Fuel_assets_model extends CI_Model {
 		}
 		return $return;
 	}
-	
 
 	// --------------------------------------------------------------------
 
@@ -260,7 +259,7 @@ class Fuel_assets_model extends CI_Model {
 	public function record_count($dir = 'images')
 	{
 		$CI =& get_instance();
-		$files = $CI->fuel->assets->dir_files($dir, false, false);
+		$files = $CI->fuel->assets->dir_files($dir, FALSE, FALSE);
 		return count($files);
 	}
 	
@@ -275,8 +274,6 @@ class Fuel_assets_model extends CI_Model {
 	 */	
 	public function delete($file)
 	{
-		$CI =& get_instance();
-
 		if (is_array($file))
 		{
 			$valid = TRUE;
@@ -425,7 +422,7 @@ class Fuel_assets_model extends CI_Model {
 		{
 			$fields['subfolder'] = array('label' => lang('form_label_subfolder'), 'comment' => lang('assets_comment_subfolder'));
 		}
-		$fields['overwrite'] = array('label' => lang('form_label_overwrite'), 'type' => 'checkbox', 'comment' => lang('assets_comment_overwrite'), 'checked' => true, 'value' => '1');
+		$fields['overwrite'] = array('label' => lang('form_label_overwrite'), 'type' => 'checkbox', 'comment' => lang('assets_comment_overwrite'), 'checked' => TRUE, 'value' => '1');
 		$fields['unzip'] = array('type' => 'checkbox', 'label' => lang('form_label_unzip'), 'comment' => lang('assets_comment_unzip'), 'value' => 1);
 
 		$fields[lang('assets_heading_image_specific')] = array('type' => 'fieldset', 'class' => 'tab');
@@ -471,8 +468,7 @@ class Fuel_assets_model extends CI_Model {
 	 * Placeholder function (not used)
 	 *
 	 * @access	public
-	 * @param   array Posted values
-	 * @return	void
+	 * @return	boolean
 	 */
 	public function has_auto_increment()
 	{
@@ -484,7 +480,7 @@ class Fuel_assets_model extends CI_Model {
 	 *
 	 * @access	public
 	 * @param   array Posted values
-	 * @return	void
+	 * @return	array
 	 */
 	public function filters($values = array())
 	{

--- a/fuel/modules/fuel/models/Fuel_assets_model.php
+++ b/fuel/modules/fuel/models/Fuel_assets_model.php
@@ -260,8 +260,7 @@ class Fuel_assets_model extends CI_Model {
 	public function record_count($dir = 'images')
 	{
 		$CI =& get_instance();
-		$assets_path = WEB_ROOT.$CI->config->item('assets_path').$dir.'/';
-		$files = $CI->fuel->assets->dir_files($assets_path, false, false);
+		$files = $CI->fuel->assets->dir_files($dir, false, false);
 		return count($files);
 	}
 	


### PR DESCRIPTION
`Fuel_assets_model` has a method `record_count`. Calling it results in the following error:

```
Type: Error
Message: Call to undefined function dir_files()
Filename: C:\wamp64\www\FUEL-CMSa\fuel\modules\fuel\models\Fuel_assets_model.php
```

`dir_files` doesn't seem to exist in any of the helper files, however there is a method with such a name in the `Fuel_assets` library.

After applying https://github.com/daylightstudio/FUEL-CMS/commit/5f8c6ac23d7c7333818cffdd7300af14451e1d15, the error was gone, however the result was '0' even though the "images" directory has a file in it. Turns out, the `record_count` function was giving `dir_files` an absolute path, which in turn called `assets_server_path` on it, resulting in a nonsense path.

