### PR TITLE
Add @property tags to Fuel

### DIFF
--- a/fuel/modules/fuel/core/MY_Model.php
+++ b/fuel/modules/fuel/core/MY_Model.php
@@ -68,7 +68,9 @@ class MY_Model extends CI_Model {
 	public $formatters = array(); // an array of helper formatter functions related to a specific field type (e.g. string, datetime, number), or name (e.g. title, content) that can augment field results
 
 	/**
-	 * @var CI_DB_query_builder CI database query builder
+	 * CI database query builder
+	 *
+	 * @var CI_DB_query_builder
 	 */
 	protected $db;
 
@@ -84,7 +86,14 @@ class MY_Model extends CI_Model {
 	protected $rules = array(); // validation rules
 	protected $fields = array(); // fields in the table
 	protected $use_common_query = TRUE; // include the _common_query method for each query
-	protected $validator = NULL; // the validator object
+
+	/**
+	 * The validator object
+	 *
+	 * @var Validator
+	 */
+	protected $validator = NULL;
+
 	protected $clear_related_on_save = 'AUTO'; // clears related records before saving
 	protected $_tables = array(); // an array of table names with the key being the alias and the value being the actual table
 	protected $_last_saved = NULL; // a reference to the last saved object / ID of record;
@@ -2572,7 +2581,7 @@ class MY_Model extends CI_Model {
 	</code>
 	 *
 	 * @access	public
-	 * @return	object
+	 * @return	Validator
 	 */	
 	public function &get_validation()
 	{

--- a/fuel/modules/fuel/helpers/fuel_helper.php
+++ b/fuel/modules/fuel/helpers/fuel_helper.php
@@ -34,7 +34,7 @@
  * Returns the instance of the FUEL object
  *
  * @access	public
- * @return	object
+ * @return	Fuel
  */
 function &fuel_instance()
 {
@@ -45,7 +45,7 @@ function &fuel_instance()
  * Returns the instance of the FUEL object just like fuel_instance but with a similar syntax to the CI() function which returns the CI object.
  * 
  * @access	public
- * @return	object
+ * @return	Fuel
  */
 function &FUEL()
 {

--- a/fuel/modules/fuel/libraries/Form.php
+++ b/fuel/modules/fuel/libraries/Form.php
@@ -33,7 +33,14 @@
 class Form {
 	
 	public $attrs = 'method="post" action=""'; // form html attributes
-	public $validator; // the validator object
+
+	/**
+	 * The validator object
+	 *
+	 * @var Validator
+	 */
+	public $validator;
+
 	public $focus_highlight_cssclass = "field_highlight"; // the focus css class
 	public $error_highlight_cssclass = "error_highlight"; // the error highlight class
 	

--- a/fuel/modules/fuel/libraries/Form_builder.php
+++ b/fuel/modules/fuel/libraries/Form_builder.php
@@ -42,7 +42,13 @@
 
 class Form_builder {
 
-	public $form; // form object used to create the form fields and associate errors with
+	/**
+	 * Form object used to create the form fields and associate errors with
+	 *
+	 * @var Form
+	 */
+	public $form;
+
 	public $id = ''; // id to be used for the containing table or div
 	public $css_class = 'form'; // css class to be used with the form
 	public $form_attrs = 'method="post" action=""'; // form tag attributes

--- a/fuel/modules/fuel/libraries/Fuel.php
+++ b/fuel/modules/fuel/libraries/Fuel.php
@@ -116,7 +116,7 @@ class Fuel extends Fuel_advanced_module {
 	 * This object is auto-loaded and so you will most likely use $this->fuel instead of this method
 	 *
 	 * @access	public
-	 * @return	object	
+	 * @return	Fuel
 	 */	
 	public static function &get_instance()
 	{

--- a/fuel/modules/fuel/libraries/Fuel.php
+++ b/fuel/modules/fuel/libraries/Fuel.php
@@ -33,8 +33,32 @@
 // include base library classes to extend
 require_once('Fuel_base_library.php');
 require_once('Fuel_advanced_module.php');
-//require_once('Fuel_modules.php');
 
+/**
+ * @property Fuel_admin			admin
+ * @property Fuel_assets		assets
+ * @property Fuel_auth			auth
+ * @property Fuel_blocks		blocks
+ * @property Fuel_cache			cache
+ * @property Fuel_categories	categories
+ * @property Fuel_installer		installer
+ * @property Fuel_language		language
+ * @property Fuel_layouts		layouts
+ * @property Fuel_logs			logs
+ * @property Fuel_modules		modules
+ * @property Fuel_navigation	navigation
+ * @property Fuel_notification	notification
+ * @property Fuel_pages			pages
+ * @property Fuel_parser		parser
+ * @property Fuel_posts			posts
+ * @property Fuel_pagevars		pagevars
+ * @property Fuel_permissions	permissions
+ * @property Fuel_redirects		redirects
+ * @property Fuel_settings		settings
+ * @property Fuel_sitevars		sitevars
+ * @property Fuel_tags			tags
+ * @property Fuel_users			users
+ */
 class Fuel extends Fuel_advanced_module {
 	protected $name = 'FUEL'; // name of the advanced module... usually the same as the folder name
 	protected $folder = 'fuel'; // name of the folder for the advanced module

--- a/fuel/modules/fuel/libraries/Fuel_base_controller.php
+++ b/fuel/modules/fuel/libraries/Fuel_base_controller.php
@@ -37,7 +37,13 @@ class Fuel_base_controller extends CI_Controller {
 	public $js_controller_params = array(); // jQX controller parameters
 	public $js_controller_path = ''; // The path to the jQX controllers. If blank it will load from the fuel/modules/fuel/assets/js/jqx/ directory
 	public $nav_selected; // the navigation item in the left menu to show selected
-	public $fuel; // the FUEL master object
+
+	/**
+	 * The FUEL master object
+	 *
+	 * @var Fuel
+	 */
+	public $fuel;
 	
 	// --------------------------------------------------------------------
 	

--- a/fuel/modules/fuel/libraries/Fuel_base_library.php
+++ b/fuel/modules/fuel/libraries/Fuel_base_library.php
@@ -31,9 +31,16 @@
 // --------------------------------------------------------------------
 
 class Fuel_base_library {
-	
+
 	protected $CI = NULL; // reference to the CI super object
-	protected $fuel = NULL; // reference to the fuel object
+
+	/**
+	 * The FUEL master object
+	 *
+	 * @var Fuel
+	 */
+	protected $fuel = NULL;
+
 	protected $permission = ''; // permission required to run
 	protected $init_permission_check = FALSE; // whether to check permissions on initialization or not
 	protected $_errors = array(); // array to keep track of errors
@@ -186,6 +193,7 @@ class Fuel_base_library {
 	 *
 	 * @access	protected
 	 * @param	string	Error message
+	 * @param	boolean	Indicates whether the values in $error correspond to language file keys
 	 * @return	void
 	 */	
 	protected function _add_error($error, $use_lang = FALSE)
@@ -220,7 +228,7 @@ class Fuel_base_library {
 	 * Checks if the logged in user is authenticated to use this item based on specified permission
 	 *
 	 * @access	protected
-	 * @return	void
+	 * @return	boolean
 	 */	
 	protected function _has_permission()
 	{

--- a/fuel/modules/fuel/libraries/Fuel_custom_fields.php
+++ b/fuel/modules/fuel/libraries/Fuel_custom_fields.php
@@ -32,6 +32,12 @@ class Fuel_custom_fields {
 	
 
 	protected $CI;
+
+	/**
+	 * The FUEL master object
+	 *
+	 * @var Fuel
+	 */
 	protected $fuel;
 	
 	// --------------------------------------------------------------------

--- a/fuel/modules/fuel/models/Base_model_helpers.php
+++ b/fuel/modules/fuel/models/Base_model_helpers.php
@@ -13,7 +13,14 @@
 abstract class Abstract_base_model_helper {
 
 	protected $values = array();
+
+	/**
+	 * Parent model object
+	 *
+	 * @var MY_Model
+	 */
 	protected $parent_model = NULL;
+
 	protected $record = NULL;
 	protected $CI = NULL;
 
@@ -558,8 +565,21 @@ class Base_model_fields extends Abstract_base_model_helper implements ArrayAcces
  */
 class Base_model_validation extends Abstract_base_model_helper  {
 
+	/**
+	 * The validator object
+	 *
+	 * @var Validator
+	 */
 	protected $validator = NULL;
 
+	/**
+	 * Constructor
+	 *
+	 * @access	public
+	 * @param	array		$record
+	 * @param	MY_Model	$parent_model
+	 * @return	void
+	 */
 	public function __construct($record = array(), $parent_model = NULL)
 	{
 		parent::__construct();
@@ -588,8 +608,8 @@ class Base_model_validation extends Abstract_base_model_helper  {
 	 * Sets the validator object initially.
 	 *
 	 * @access	public
-	 * @param	array 	The validator to set
-	 * @return	object 	Instance of Base_model_validation
+	 * @param	Validator	The validator to set
+	 * @return	object		Instance of Base_model_validation
 	 */	
 	public function set_validator($validator)
 	{
@@ -603,7 +623,7 @@ class Base_model_validation extends Abstract_base_model_helper  {
 	 * Returns the validator object.
 	 *
 	 * @access	public
-	 * @return	object
+	 * @return	Validator
 	 */	
 	public function get_validator()
 	{
@@ -616,11 +636,13 @@ class Base_model_validation extends Abstract_base_model_helper  {
 	 * Adds an error to the parent models validator object
 	 *
 	 * @access	public
-	 * @return	object
+	 * @param	string	error message
+	 * @param	string	key value of error message (optional)
+	 * @return	void
 	 */	
 	public function add_error($msg, $key = NULL)
 	{
-		return $this->parent_model->add_error($msg, $key);
+		$this->parent_model->add_error($msg, $key);
 	}
 
 	// --------------------------------------------------------------------
@@ -632,6 +654,7 @@ class Base_model_validation extends Abstract_base_model_helper  {
 	 * @param	string	field name
 	 * @param	mixed	function name OR array($object_instance, $method)
 	 * @param	string	error message to display
+	 * @param	array
 	 * @return	object 	Instance of Base_model_validation
 	 */	
 	public function add($field, $rule, $msg = '', $params = array())

--- a/fuel/modules/fuel/models/Base_model_helpers.php
+++ b/fuel/modules/fuel/models/Base_model_helpers.php
@@ -16,6 +16,12 @@ abstract class Abstract_base_model_helper {
 	protected $parent_model = NULL;
 	protected $record = NULL;
 	protected $CI = NULL;
+
+	/**
+	 * The FUEL master object
+	 *
+	 * @var Fuel
+	 */
 	protected $fuel = NULL;
 
 	public function __construct($record = array(), $parent_model = NULL)

--- a/fuel/modules/fuel/models/Base_module_model.php
+++ b/fuel/modules/fuel/models/Base_module_model.php
@@ -57,7 +57,14 @@ class Base_module_model extends MY_Model {
 	public $limit_to_user_field = ''; // a user ID field in your model that can be used to limit records based on the logged in user
 	public static $tables = array(); // cached array of table names that can be accessed statically
 	protected $CI = NULL; // reference to the main CI object
-	protected $fuel = NULL; // reference to the FUEL object
+
+	/**
+	 * The FUEL master object
+	 *
+	 * @var Fuel
+	 */
+	protected $fuel = NULL;
+
 	protected $_formatters = array(
 								'datetime'			=> array(
 															'formatted' => 'date_formatter',

--- a/fuel/modules/fuel/models/Fuel_assets_model.php
+++ b/fuel/modules/fuel/models/Fuel_assets_model.php
@@ -35,8 +35,13 @@ class Fuel_assets_model extends CI_Model {
 	public $key_field = 'id'; // placed here to prevent errors since we are not extended Base_module_model
 	public $boolean_fields = array(); // placed here to prevent errors since we are not extended Base_module_model
 	public $default_file_types = 'jpg|jpeg|jpe|png|gif|mov|mpeg|mp3|wav|aiff|pdf|css'; // default file types to associate to folders without associations
-	
-	protected $validator = NULL; // the validator object
+
+	/**
+	 * The validator object
+	 *
+	 * @var Validator
+	 */
+	protected $validator = NULL;
 
 	private $_encoded = FALSE;
 
@@ -56,7 +61,6 @@ class Fuel_assets_model extends CI_Model {
 		
 		$this->validator = new Validator();
 		$this->validator->register_to_global_errors = FALSE;
-		
 	}
 	
 	/**


### PR DESCRIPTION
More help for the IDEs!

With this change, PhpStorm allows me to CTRL+Click on any keyword in the following:

```php
$this->fuel->auth->user_data('id')
```

Before it would've been stuck at `fuel`, and wouldn't know what `auth` referred to. This will save devs a lot of time as they won't need to remember what the name of each class in the Fuel library is.