### PR TITLE
Fix FUEL not finding pages whose location starts with 'http'

### DIFF
--- a/fuel/modules/fuel/models/Fuel_pages_model.php
+++ b/fuel/modules/fuel/models/Fuel_pages_model.php
@@ -193,8 +193,7 @@ class Fuel_pages_model extends Base_module_model {
 	 */	
 	public function find_by_location($location, $just_published = 'yes')
 	{
-		
-		if (substr($location, 0, 4) == 'http')
+		if (strpos($location, 'http://') === 0 || strpos($location, 'https://') === 0)
 		{
 			$location = substr($location, strlen(site_url()));
 		}


### PR DESCRIPTION
If a page's location starts with `http`, it will not be found by FUEL CMS. Even if it is a local path such as "http_page".

To reproduce, set up a page in the CMS with a location of "http_test", and then try to view it.