### PR TITLE
F remove unsupported php version check

### DIFF
--- a/fuel/modules/fuel/helpers/MY_string_helper.php
+++ b/fuel/modules/fuel/helpers/MY_string_helper.php
@@ -203,7 +203,7 @@ if (!function_exists('safe_htmlentities'))
 	function safe_htmlentities($str, $protect_amp = TRUE)
 	{
 		// convert all hex single quotes to numeric ... 
-		// this was due to an issue we saw with htmlentities still encoding it's ampersand again'... 
+		// this was due to an issue we saw with htmlentities still encoding it's ampersand again...
 		// but was inconsistent across different environments and versions... not sure the issue
 		// may need to look into other hex characters
 		$str = str_replace('&#x27;', '&#39;', $str);
@@ -220,17 +220,8 @@ if (!function_exists('safe_htmlentities'))
 		}
 
 		// safely translate now
-		if (version_compare(PHP_VERSION, '5.2.3', '>='))
-		{
-			//$str = htmlspecialchars($str, ENT_NOQUOTES, 'UTF-8', FALSE);
-			$str = htmlentities($str, ENT_NOQUOTES, config_item('charset'), FALSE);
-		}
-		else
-		{
-			$str = preg_replace('/&(?!(?:#\d++|[a-z]++);)/ui', '&amp;', $str);
-			$str = str_replace(array('<', '>'), array('&lt;', '&gt;'), $str);
-		}
-		
+		$str = htmlentities($str, ENT_NOQUOTES, config_item('charset'), FALSE);
+
 		// translate everything back
 		$str = str_replace($find, array('<','>'), $str);
 		$str = str_replace($replace, $find, $str);

--- a/fuel/modules/fuel/libraries/Form.php
+++ b/fuel/modules/fuel/libraries/Form.php
@@ -568,9 +568,10 @@ class Form {
 	// will echo the following
 	This will safely prep the form field text with entities like &amp;amp; in it
 	</code>
-	 * @access public
-	 * @param string elements value
-	 * @return string
+	 * @access	public
+	 * @param	string	elements value
+	 * @param	boolean
+	 * @return	string
 	 */
 	public static function prep($str, $double_encode = TRUE)
 	{
@@ -581,24 +582,7 @@ class Form {
 		$CI =& get_instance();
 		$str = $CI->utf8->clean_string($str);
 
-		if ($double_encode === TRUE)
-		{
-			$str = htmlspecialchars($str, ENT_QUOTES, config_item('charset'));
-		}
-		else
-		{
-			// Do not encode existing HTML entities
-			// From PHP 5.2.3 this functionality is built-in, otherwise use a regex
-			if (version_compare(PHP_VERSION, '5.2.3', '>='))
-			{
-				$str = htmlspecialchars($str, ENT_QUOTES, config_item('charset'), FALSE);
-			}
-			else
-			{
-				$str = preg_replace('/&(?!(?:#\d++|[a-z]++);)/ui', '&amp;', $str);
-				//$str = str_replace(array(''\'', '"'), array('&#39;', '&quot;'), $str);
-			}
-		}
+		$str = htmlspecialchars($str, ENT_QUOTES, config_item('charset'), $double_encode);
 		return $str;
 	}
 	


### PR DESCRIPTION
Fuel CMS requires PHP 5.4+.

There are a couple of functions in the code base that check if the user is on 5.2.3+.

These checks should be deleted as it adds more complexity to the code and results in more code to maintain.