### PR TITLE
F google helper create function

### DIFF
--- a/fuel/modules/fuel/helpers/google_helper.php
+++ b/fuel/modules/fuel/helpers/google_helper.php
@@ -396,7 +396,6 @@ if (!function_exists('google_geolocate'))
 				}
 			}
 			$CI->curl->close();
-			//curl_close($ch);
 		}
 		else
 		{
@@ -408,34 +407,34 @@ if (!function_exists('google_geolocate'))
 			return NULL;
 		}
 
-		$lookup_func = create_function('$data, $key, $single = FALSE', '
-				$components = $data["address_components"];
-				$return = array("long_name" => "", "short_name" => "");
+		$lookup_func = function($data, $key, $single = FALSE) {
+			$components = $data['address_components'];
+			$return = array('long_name' => '', 'short_name' => '');
 
-				foreach($components as $c)
+			foreach($components as $c)
+			{
+				if (isset($c['types']) AND in_array($key, $c['types']))
 				{
-					if (isset($c["types"]) AND in_array($key, $c["types"]))
+					if (isset($c['long_name']))
 					{
-						if (isset($c["long_name"]))
+						$return['long_name'] = $c['long_name'];
+						if ($single)
 						{
-							$return["long_name"] = $c["long_name"];
-							if ($single)
-							{
-								return $return["long_name"];
-							}
+							return $return['long_name'];
 						}
-						if (isset($c["short_name"]))
-						{
-							$return["short_name"] = $c["short_name"];
-							if ($single)
-							{
-								return $return["long_name"];
-							}
-						}
-						return $return;
 					}
+					if (isset($c['short_name']))
+					{
+						$return['short_name'] = $c['short_name'];
+						if ($single)
+						{
+							return $return['long_name'];
+						}
+					}
+					return $return;
 				}
-			');
+			}
+		};
 
 		$return = strtolower($return);
 		switch($return)

--- a/fuel/modules/fuel/tests/Format_helper_test.php
+++ b/fuel/modules/fuel/tests/Format_helper_test.php
@@ -66,6 +66,8 @@ class Format_helper_test extends Tester_base {
 		$this->run($actual, $expected, 'include_cents FALSE');
 	}
 
+	// ------------------------------------------------------------------------
+
 	public function test_currency_includeCentsNull()
 	{
 		$actual = currency('5', '$', NULL);

--- a/fuel/modules/fuel/tests/Google_helper_test.php
+++ b/fuel/modules/fuel/tests/Google_helper_test.php
@@ -1,4 +1,4 @@
-<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+<?php  if (!defined('BASEPATH')) exit('No direct script access allowed');
 
 require_once('Fuel_test_base.php');
 
@@ -9,11 +9,11 @@ require_once('Fuel_test_base.php');
  * An open source Content Management System based on the
  * Codeigniter framework (http://codeigniter.com)
  *
- * @package        FUEL CMS
- * @author        David McReynolds @ Daylight Studio
- * @copyright    Copyright (c) 2018, Daylight Studio LLC.
- * @license        http://docs.getfuelcms.com/general/license
- * @link        http://www.getfuelcms.com
+ * @package		FUEL CMS
+ * @author		David McReynolds @ Daylight Studio
+ * @copyright	Copyright (c) 2018, Daylight Studio LLC.
+ * @license		http://docs.getfuelcms.com/general/license
+ * @link		http://www.getfuelcms.com
  * @filesource
  */
 
@@ -22,11 +22,11 @@ require_once('Fuel_test_base.php');
 /**
  * FUEL Google Helper Test
  *
- * @package        FUEL CMS
- * @subpackage    Helpers
- * @category    Helpers
- * @author        David McReynolds @ Daylight Studio
- * @link        http://docs.getfuelcms.com/helpers/format_helper
+ * @package		FUEL CMS
+ * @subpackage	Helpers
+ * @category	Helpers
+ * @author		David McReynolds @ Daylight Studio
+ * @link		http://docs.getfuelcms.com/helpers/format_helper
  */
 
 // ------------------------------------------------------------------------

--- a/fuel/modules/fuel/tests/Google_helper_test.php
+++ b/fuel/modules/fuel/tests/Google_helper_test.php
@@ -1,0 +1,84 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+require_once('Fuel_test_base.php');
+
+/**
+ * FUEL CMS
+ * http://www.getfuelcms.com
+ *
+ * An open source Content Management System based on the
+ * Codeigniter framework (http://codeigniter.com)
+ *
+ * @package        FUEL CMS
+ * @author        David McReynolds @ Daylight Studio
+ * @copyright    Copyright (c) 2018, Daylight Studio LLC.
+ * @license        http://docs.getfuelcms.com/general/license
+ * @link        http://www.getfuelcms.com
+ * @filesource
+ */
+
+// ------------------------------------------------------------------------
+
+/**
+ * FUEL Google Helper Test
+ *
+ * @package        FUEL CMS
+ * @subpackage    Helpers
+ * @category    Helpers
+ * @author        David McReynolds @ Daylight Studio
+ * @link        http://docs.getfuelcms.com/helpers/format_helper
+ */
+
+// ------------------------------------------------------------------------
+
+class Google_helper_test extends Tester_base
+{
+	private $data = array();
+
+	public function setup()
+	{
+		parent::setup();
+		$this->CI->load->helper('google');
+
+		$this->data = array(
+			'address_components' => array(
+				array(
+					'types' => array('route'),
+					'long_name' => 'route long name',
+					'short_name' => 'route short name',
+				),
+			),
+		);
+	}
+
+	// ------------------------------------------------------------------------
+
+	public function test_google_geolocate_return_address_components()
+	{
+		$actual = google_geolocate($this->data, 'address_components');
+		$expected = $this->data['address_components'];
+		$this->run($actual, $expected, 'google_geolocate return address_components');
+	}
+
+	// ------------------------------------------------------------------------
+
+	public function test_google_geolocate_return_route_long()
+	{
+		$actual = google_geolocate($this->data, 'route', TRUE);
+		$expected = 'route long name';
+		$this->run($actual, $expected, 'google_geolocate return route (long)');
+	}
+
+	// ------------------------------------------------------------------------
+
+	public function test_google_geolocate_return_route_short()
+	{
+		$actual = google_geolocate($this->data, 'route', FALSE);
+		$expected = 'route short name';
+		$this->run($actual, $expected, 'google_geolocate return route (short)');
+	}
+
+}
+
+/* End of file Google_helper_test.php */
+/* Location: ./modules/fuel/tests/Google_helper_test.php */


### PR DESCRIPTION
`create_function` has been deprecated as of PHP 7.2.0.

There are a number of uses throughout FUEL CMS.

As they internally invoke `eval` it's a good idea to remove them as they're way slower than anonymous functions, and reduce readability (a lot of IDEs just parse their content as strings).

I set up some unit tests before applying the change to make sure nothing's changed.