### PR TITLE
Fix for when $wildcard_location undefined, at line 234

### DIFF
--- a/fuel/modules/fuel/models/Fuel_pages_model.php
+++ b/fuel/modules/fuel/models/Fuel_pages_model.php
@@ -193,6 +193,7 @@ class Fuel_pages_model extends Base_module_model {
 	 */	
 	public function find_by_location($location, $just_published = 'yes')
 	{
+		$wildcard_location = '';
 		
 		if (substr($location, 0, 4) == 'http')
 		{

--- a/fuel/modules/fuel/views/_generate/simple/MY_fuel_modules.php
+++ b/fuel/modules/fuel/views/_generate/simple/MY_fuel_modules.php
@@ -1,4 +1,5 @@
 $config['modules']['{module}'] = array(
 	'preview_path' => '', // put in the preview path on the site e.g products/{slug}
 	'model_location' => '{advanced_module}', // put in the advanced module name here
+	'module_uri' => '{advanced_module}/{module}' // IMPORTANT! need to define so actions buttons (eg create) have right urls
 );


### PR DESCRIPTION
Whilst upgrading a site to v1.4, I hit a situation where a url /Welcome would error if /welcome was used (undefined variable wildcard_location). The upgrade was a bit mussed up at that point, admittedly.

I can't repeat the same situation with the current master though.