### PR TITLE
Add missing closing bracket in code example

### DIFF
--- a/fuel/modules/fuel/views/_docs/general/opt-in-controllers.php
+++ b/fuel/modules/fuel/views/_docs/general/opt-in-controllers.php
@@ -110,9 +110,9 @@ class About extends CI_Controller {
 		
 		// use Fuel_page to render so it will grab all opt-in variables and do any necessary parsing
 		$this->fuel->pages->render('about/contact', $vars);
-		
-		
 	}
+
+}
 </pre>
 
 


### PR DESCRIPTION
I wanted to grab a code snippet from the FUEL docs when setting up a Controller, and noticed it was missing a closing bracket.