### PR TITLE
Update CodeIgniter user guide URLs

### DIFF
--- a/fuel/modules/fuel/libraries/Fuel_assets.php
+++ b/fuel/modules/fuel/libraries/Fuel_assets.php
@@ -439,7 +439,7 @@ class Fuel_assets extends Fuel_base_library {
 	// --------------------------------------------------------------------
 	
 	/**
-	 * Returns the <a href="http://ellislab.com/codeigniter/user-guide/libraries/file_uploading.html" target="_blank">uploaded file information</a>.
+	 * Returns the <a href="https://www.codeigniter.com/user_guide/libraries/file_uploading.html" target="_blank">uploaded file information</a>.
 	 *
 	 * @access	public
 	 * @param	string	The uploaded $_FILE key value (optional)
@@ -457,7 +457,7 @@ class Fuel_assets extends Fuel_base_library {
 	// --------------------------------------------------------------------
 	
 	/**
-	 * Normalizes the $_FILES array so that the <a href="http://ellislab.com/codeigniter/user-guide/libraries/file_uploading.html" target="_blank">CI File Upload Class</a> will work correctly
+	 * Normalizes the $_FILES array so that the <a href="https://www.codeigniter.com/user_guide/libraries/file_uploading.html" target="_blank">CI File Upload Class</a> will work correctly
 	 *
 	 * @access	public
 	 * @return	void

--- a/fuel/modules/fuel/libraries/Fuel_layouts.php
+++ b/fuel/modules/fuel/libraries/Fuel_layouts.php
@@ -954,7 +954,7 @@ class Fuel_layout extends Fuel_base_library {
 	 *
 	 * @access	public
 	 * @param	key		The type of hook (e.g. "pre_render" or "post_render")
-	 * @param	array	An array of hook information including the class/callback function. <a href="http://ellislab.com/codeigniter/user-guide/general/hooks.html" target="blank">More here</a>
+	 * @param	array	An array of hook information including the class/callback function. <a href="https://www.codeigniter.com/user_guide/general/hooks.html" target="blank">More here</a>
 	 * @return	object 	reference to this Fuel_layout object
 	 */
 	public function set_hook($type, $hook)

--- a/fuel/modules/fuel/views/_docs/general/configs-settings.php
+++ b/fuel/modules/fuel/views/_docs/general/configs-settings.php
@@ -51,19 +51,19 @@ $config['my_module']['settings']['my_config'] = array();
 	<li><strong>autoload:</strong> sets the packages, libraries, helpers, configs, languages and model files. 
 		FUEL automatically includes the <span class="file">fuel/modules/fuel</span> folder as a package path which allows 
 		it to store a lot of the files in that folder instead of the <span class="file">fuel/application</span> folder</li>
-	<li><strong>config:</strong> the <a href="http://ellislab.com/codeigniter/user-guide/libraries/config.html" target="_blank">CodeIgniter config file</a></li>
+	<li><strong>config:</strong> the <a href="https://www.codeigniter.com/user_guide/libraries/config.html" target="_blank">CodeIgniter config file</a></li>
 	<li><strong>constants:</strong> includes both the Codeigniter and FUEL specific constants and is loaded very early on in the bootstrap process</li>
-	<li><strong>database:</strong> the <a href="http://ellislab.com/codeigniter/user-guide/database/configuration.html" target="_blank">CodeIgniter database config file</a></li>
-	<li><strong>doctypes:</strong> used in the <a href="http://ellislab.com/codeigniter/user-guide/helpers/html_helper.html#doctype" target="_blank">CodeIgniter HTML helper function <dfn>doctype()</dfn></a></li>
-	<li><strong>foreign_chars:</strong>  used in the <a href="http://ellislab.com/codeigniter/user-guide/helpers/text_helper.html" target="_blank">CodeIgniter text helper function <dfn>convert_accented_characters()</dfn></a></li>
-	<li><strong>hooks:</strong> the <a href="http://ellislab.com/codeigniter/user-guide/general/hooks.html" target="_blank">CodeIgniter Hooks</a> configuration. By default it includes the <span class="file">fuel/modules/fuel/config/fuel_hooks.php</span>
+	<li><strong>database:</strong> the <a href="https://www.codeigniter.com/user_guide/database/configuration.html" target="_blank">CodeIgniter database config file</a></li>
+	<li><strong>doctypes:</strong> used in the <a href="https://www.codeigniter.com/user_guide/helpers/html_helper.html#doctype" target="_blank">CodeIgniter HTML helper function <dfn>doctype()</dfn></a></li>
+	<li><strong>foreign_chars:</strong>  used in the <a href="https://www.codeigniter.com/user_guide/helpers/text_helper.html#convert_accented_characters" target="_blank">CodeIgniter text helper function <dfn>convert_accented_characters()</dfn></a></li>
+	<li><strong>hooks:</strong> the <a href="https://www.codeigniter.com/user_guide/general/hooks.html" target="_blank">CodeIgniter Hooks</a> configuration. By default it includes the <span class="file">fuel/modules/fuel/config/fuel_hooks.php</span>
 		file which contains FUEL specific hooks. </li>
-	<li><strong>migration:</strong> the <a href="http://ellislab.com/codeigniter/user-guide/libraries/migration.html" target="_blank">CodeIgniter Migration</a> configuration. </li>
-	<li><strong>mimes:</strong> the <a href="http://ellislab.com/codeigniter/user-guide/libraries/migration.html" target="_blank">CodeIgniter mimes</a> configuration used by such classes 
-			as the CodeIgniter <a href="http://ellislab.com/codeigniter/user-guide/libraries/output.html" target="_blank">Output class</a>, the <a href="http://ellislab.com/codeigniter/user-guide/libraries/file_uploading.html" target="_blank">Upload class</a>, 
-			the <a href="http://ellislab.com/codeigniter/user-guide/helpers/file_helper.html" target="_blank">file helper</a> and the <a href="http://ellislab.com/codeigniter/user-guide/helpers/download_helper.html" target="_blank">download helper</a>.</li>
-	<li><strong>routes:</strong> the <a href="http://ellislab.com/codeigniter/user-guide/general/routing.html" target="_blank">CodeIgniter Routing</a> configuration</li>
-	<li><strong>smileys:</strong> the <a href="http://ellislab.com/codeigniter/user-guide/helpers/smiley_helper.html" target="_blank">Smiley helper function</a> configuration</li>
+	<li><strong>migration:</strong> the <a href="https://www.codeigniter.com/user_guide/libraries/migration.html" target="_blank">CodeIgniter Migration</a> configuration. </li>
+	<li><strong>mimes:</strong> the <a href="https://www.codeigniter.com/user_guide/libraries/migration.html" target="_blank">CodeIgniter mimes</a> configuration used by such classes
+			as the CodeIgniter <a href="https://www.codeigniter.com/user_guide/libraries/output.html" target="_blank">Output class</a>, the <a href="https://www.codeigniter.com/user_guide/libraries/file_uploading.html" target="_blank">Upload class</a>,
+			the <a href="https://www.codeigniter.com/user_guide/helpers/file_helper.html" target="_blank">file helper</a> and the <a href="https://www.codeigniter.com/user_guide/helpers/download_helper.html" target="_blank">download helper</a>.</li>
+	<li><strong>routes:</strong> the <a href="https://www.codeigniter.com/user_guide/general/routing.html" target="_blank">CodeIgniter Routing</a> configuration</li>
+	<li><strong>smileys:</strong> the <a href="https://www.codeigniter.com/user_guide/helpers/smiley_helper.html" target="_blank">Smiley helper function</a> configuration</li>
 </ul>
 
 

--- a/fuel/modules/fuel/views/_docs/general/constants.php
+++ b/fuel/modules/fuel/views/_docs/general/constants.php
@@ -1,5 +1,5 @@
 <h1>FUEL Constants</h1>
-<p>In addition to the <a href="http://ellislab.com/codeigniter/user-guide/general/reserved_names.html" target="_blank">CodeIgniter constants</a>, FUEL CMS provides the following:</p>
+<p>In addition to the <a href="https://www.codeigniter.com/user_guide/general/reserved_names.html" target="_blank">CodeIgniter constants</a>, FUEL CMS provides the following:</p>
 
 <ul>
 	<li><strong>FUEL_VERSION</strong>: The current version number of FUEL</li>

--- a/fuel/modules/fuel/views/_docs/general/forms.php
+++ b/fuel/modules/fuel/views/_docs/general/forms.php
@@ -998,7 +998,7 @@ $this->form_builder->register_custom_field($key, $custom_field);
 
 <h3 id="slug" class="toggle">slug</h3>
 <div class="toggle_block_off">
-	<p>This field type can be used for creating slug or permalink values for a field using the <a href="http://ellislab.com/codeigniter/user-guide/helpers/url_helper.html" target="_blank">url_title</a> function.
+	<p>This field type can be used for creating slug or permalink values for a field using the <a href="https://www.codeigniter.com/user_guide/helpers/url_helper.html#url_title" target="_blank">url_title</a> function.
 	The following additional parameter can be passed to this field type:</p>
 	<ul>
 		<li><strong>linked_to</strong>: the field whose value to use if no value is provided.

--- a/fuel/modules/fuel/views/_docs/general/javascript.php
+++ b/fuel/modules/fuel/views/_docs/general/javascript.php
@@ -161,7 +161,7 @@ Essentially, you can swap out the folder "/" with object ".".</p>
 <h3>jQX Configuration Parameters</h3>
 <p>The following jqx config parameters are available for you to use in your jQX controller:</p>
 <ul>
-	<li><strong>jqx.config.basePath:</strong> The equivalent value to the <a href="http://ellislab.com/codeigniter/user-guide/helpers/url_helper.html" target="_blank">site_url()</a> CI function </li>
+	<li><strong>jqx.config.basePath:</strong> The equivalent value to the <a href="https://www.codeigniter.com/user_guide/helpers/url_helper.html#site_url" target="_blank">site_url()</a> CI function </li>
 	<li><strong>jqx.config.jsPath:</strong> The path to the fuel modules javascript folder which is <span class="file">/fuel/modules/fuel/assets/js/</span></li>
 	<li><strong>jqx.config.imgPath:</strong> The path to the fuel modules images folder which is <span class="file">/fuel/modules/fuel/assets/images/</span></li>
 	<li><strong>jqx.config.uriPath:</strong> The equivalent to the <a href="<?=user_guide_url('helpers/my_url_helper')?>">uri_path()</a> function</li>

--- a/fuel/modules/fuel/views/_docs/general/localization.php
+++ b/fuel/modules/fuel/views/_docs/general/localization.php
@@ -9,7 +9,7 @@ can then be used to help set and retrieve language information.</p>
 <p>There are a few different ways to add multi-language support to your website:</p>
 
 <h3>CodIgniter's Language Class</h3>
-<p>CodeIgniter comes with a <a href="http://ellislab.com/codeigniter/user-guide/libraries/language.html" target="_blank">Language class</a> which can is fully available for you to leverage in your site.</p>
+<p>CodeIgniter comes with a <a href="https://www.codeigniter.com/user_guide/libraries/language.html" target="_blank">Language class</a> which can is fully available for you to leverage in your site.</p>
 
 <h3>CMS Pages</h3>
 <p>When multiple languages are configured in the <a href="<?=user_guide_url('installation/configuration')?>">FUEL config</a>, you will see an additional drop down when editing or creating a page in the CMS.

--- a/fuel/modules/fuel/views/_docs/general/migrations.php
+++ b/fuel/modules/fuel/views/_docs/general/migrations.php
@@ -1,5 +1,5 @@
 <h1>Migrations</h1>
-<p>FUEL CMS provides a command line utility for using <a href="http://ellislab.com/codeigniter/user-guide/libraries/migration.html" target="_blank">CodeIgniter's migrations</a>.</p>
+<p>FUEL CMS provides a command line utility for using <a href="https://www.codeigniter.com/user_guide/libraries/migration.html" target="_blank">CodeIgniter's migrations</a>.</p>
 
 <pre class="brush:php">
 // updates to the latest migration file regardless of what is specified in the migrations table

--- a/fuel/modules/fuel/views/_docs/general/models.php
+++ b/fuel/modules/fuel/views/_docs/general/models.php
@@ -7,8 +7,8 @@ $my_model = $classes['MY_Model'];
 
 <h1>Models</h1>
 <p>There are two main classes FUEL provides for creating models. The first, <a href="<?=user_guide_url('libraries/my_model')?>">MY_Model</a>, 
-extends the <a href="http://ellislab.com/codeigniter/user-guide/general/models.html" target="_blank">CI_Model class</a> to provide <a href="<?=user_guide_url('libraries/my_model')?>">common methods</a> for retrieving and manipulating data from the database usually specific to a table.
-It was developed to augment the <a href="http://ellislab.com/codeigniter/user-guide/database/active_record.html" target="_blank">CodeIgniter active record</a> class and <strong>DOES NOT</strong> change any of those methods.
+extends the <a href="https://www.codeigniter.com/user_guide/general/models.html" target="_blank">CI_Model class</a> to provide <a href="<?=user_guide_url('libraries/my_model')?>">common methods</a> for retrieving and manipulating data from the database usually specific to a table.
+It was developed to augment the <a href="https://www.codeigniter.com/userguide2/database/active_record.html" target="_blank">CodeIgniter active record</a> class and <strong>DOES NOT</strong> change any of those methods.
 The second, <a href="<?=user_guide_url('libraries/base_module_model')?>">Base_module_model</a>, extends <a href="<?=user_guide_url('libraries/my_model')?>">MY_Model</a> and provides 
 <a href="<?=user_guide_url('modules/simple')?>">simple module</a> specific methods and is the class you will most likely want to extend for your models. </p>
 
@@ -92,7 +92,7 @@ class Quote_model extends Base_module_record {
 	<li><a href="<?=user_guide_url('libraries/validator')?>">Validator Class</a></li>
 	<li><a href="<?=user_guide_url('helpers/my_string_helper')?>">String Helper</a></li>
 	<li><a href="<?=user_guide_url('helpers/my_date_helper')?>">Date Helper</a></li>
-	<li><a href="http://ellislab.com/codeigniter/user-guide/helpers/security_helper.html">Security Helper</a></li>
+	<li><a href="https://www.codeigniter.com/user_guide/helpers/security_helper.html">Security Helper</a></li>
 </ul>
 
 <h2 id="table_result_record_field">Table, Result, Record and Field Classes</h2>
@@ -302,7 +302,7 @@ $record->content
 </pre>
 
 <p>There are also additional <a href="#formattters">formatter</a> variations you can use on a record property &mdash; such as <dfn>{property}_formatted</dfn> and <dfn>{property}_stripped</dfn>.</p>
-<p>Using <dfn>{property}_formatted</dfn> will apply the <a href="http://ellislab.com/codeigniter/user-guide/helpers/typography_helper.html" target="_blank">auto_typography</a>
+<p>Using <dfn>{property}_formatted</dfn> will apply the <a href="https://www.codeigniter.com/user_guide/helpers/typography_helper.html" target="_blank">auto_typography</a>
 function if the property is a string value and if it is a date value will format the date by default to whatever is specified in the <span class="file">fuel/application/config/MY_config.php</span>.
 </p>
 <pre class="brush: php">
@@ -595,7 +595,7 @@ an array of values to be processed and should return the processed array.</p>
 
 <h2 id="formatters">Formatters</h2>
 <p>Formatters allow you to easily modify a value by mapping a function to a suffix value of a property. 
-An example of this is to use the "_formatted" suffix on a string type field which would apply the <a href="http://ellislab.com/codeigniter/user-guide/helpers/typography_helper.html" target="_blank">auto_typography</a>.</p>
+An example of this is to use the "_formatted" suffix on a string type field which would apply the <a href="https://www.codeigniter.com/user_guide/helpers/typography_helper.html" target="_blank">auto_typography</a>.</p>
 
 <pre class="brush:php">
 echo $record->content;
@@ -643,18 +643,18 @@ $record->format('content', array('stripped', 'formatted');
 <h3>String Field Examples</h3>
 <p>Below are examples of formatters that can be applied to a string fields (char, varchar, text) and links to the functions that they use.</p>
 <ul>
-	<li><a href="http://ellislab.com/codeigniter/user-guide/helpers/typography_helper.html" target="_blank">{string}_formatted</a> (auto_typography CI function)</li>
+	<li><a href="https://www.codeigniter.com/user_guide/helpers/typography_helper.html#auto_typography" target="_blank">{string}_formatted</a> (auto_typography CI function)</li>
 	<li><a href="http://php.net/manual/en/function.strip-tags.php" target="_blank">{string}_stripped</a></li>
 	<li><a href="<?=user_guide_url('helpers/markdown_helper')?>">{string}_markdown</a></li>
 	<li><a href="<?=user_guide_url('helpers/my_string_helper#func_parse_template_syntax')?>">{string}_parsed</a></li>
-	<li><a href="http://ellislab.com/codeigniter/user-guide/helpers/text_helper.html" target="_blank">{string}_excerpt</a> (word_limiter CI function)</li>
-	<li><a href="http://ellislab.com/codeigniter/user-guide/helpers/text_helper.html" target="_blank">{string}_ellipsize</a> (ellipsize CI function)</li>
-	<li><a href="http://ellislab.com/codeigniter/user-guide/helpers/text_helper.html" target="_blank">{string}_highlight</a> (highlight_phrase CI function)</li>
+	<li><a href="https://www.codeigniter.com/user_guide/helpers/text_helper.html#word_limiter" target="_blank">{string}_excerpt</a> (word_limiter CI function)</li>
+	<li><a href="https://www.codeigniter.com/user_guide/helpers/text_helper.html#ellipsize" target="_blank">{string}_ellipsize</a> (ellipsize CI function)</li>
+	<li><a href="https://www.codeigniter.com/user_guide/helpers/text_helper.html#highlight_phrase" target="_blank">{string}_highlight</a> (highlight_phrase CI function)</li>
 	<li><a href="http://us2.php.net/manual/en/function.htmlentities.php" target="_blank">{string}_entities</a></li>
 	<li><a href="http://us2.php.net/manual/en/function.htmlspecialchars.php" target="_blank">{string}_specialchars</a></li>
-	<li><a href="http://ellislab.com/codeigniter/user-guide/helpers/inflector_helper.html" target="_blank">{string}_humanize</a> (humanize CI function)</li>
-	<li><a href="http://ellislab.com/codeigniter/user-guide/helpers/inflector_helper.html" target="_blank">{string}_underscore</a> (underscore CI function)</li>
-	<li><a href="http://ellislab.com/codeigniter/user-guide/helpers/inflector_helper.html" target="_blank">{string}_camelize</a> (camelize CI function)</li>
+	<li><a href="https://www.codeigniter.com/user_guide/helpers/inflector_helper.html#humanize" target="_blank">{string}_humanize</a> (humanize CI function)</li>
+	<li><a href="https://www.codeigniter.com/user_guide/helpers/inflector_helper.html#underscore" target="_blank">{string}_underscore</a> (underscore CI function)</li>
+	<li><a href="https://www.codeigniter.com/user_guide/helpers/inflector_helper.html#camelize" target="_blank">{string}_camelize</a> (camelize CI function)</li>
 </ul>
 
 <h3>Number Examples</h3>
@@ -666,8 +666,8 @@ $record->format('content', array('stripped', 'formatted');
 <h3>Special Field Name Examples</h3>
 <p>Below are examples of formatters that can be applied to a number type fields (tinyint, smallint, int, bigint) and links to the functions that they use.</p>
 <ul>
-	<li><a href="http://ellislab.com/codeigniter/user-guide/helpers/url_helper.html" target="_blank">{url|link}_path</a> (site_url CI function)</li>
-	<li><a href="http://ellislab.com/codeigniter/user-guide/helpers/url_helper.html" target="_blank">{url|link}_prep</a> (prep_url CI function)</li>
+	<li><a href="https://www.codeigniter.com/user_guide/helpers/url_helper.html#site_url" target="_blank">{url|link}_path</a> (site_url CI function)</li>
+	<li><a href="https://www.codeigniter.com/user_guide/helpers/url_helper.html#prep_url" target="_blank">{url|link}_prep</a> (prep_url CI function)</li>
 	<li><a href="<?=user_guide_url('helpers/asset_helper#func_assets_path')?>">{img|image|thumb|pdf}_path</a></li>
 	<li><a href="<?=user_guide_url('helpers/asset_helper#func_assets_server_path')?>">{img|image|thumb|pdf}_serverpath</a></li>
 	<li><a href="<?=user_guide_url('helpers/asset_helper#func_asset_filesize')?>">{img|image|thumb|pdf}_filesize</a></li>

--- a/fuel/modules/fuel/views/_docs/general/redirects.php
+++ b/fuel/modules/fuel/views/_docs/general/redirects.php
@@ -22,7 +22,7 @@ $config['passive_redirects'] = array(
 									);
 </pre>
 
-<p class="important">Key values can use regular expression syntax similar to <a href="http://ellislab.com/codeigniter/user-guide/general/routing.html" target="_blank">routes</a>.</p>
+<p class="important">Key values can use regular expression syntax similar to <a href="https://www.codeigniter.com/user_guide/general/routing.html" target="_blank">routes</a>.</p>
 
 <br />
 

--- a/fuel/modules/fuel/views/_docs/general/security.php
+++ b/fuel/modules/fuel/views/_docs/general/security.php
@@ -19,7 +19,7 @@ CI application.</p>
 <p>Additionally, the following module specific security settings exist:</p>
 <ul>
 	<li><strong>sanitize_input</strong> - cleans the input before inserting or updating the data source. 
-		A value of <dfn>TRUE</dfn>, will apply the <a href="http://ellislab.com/codeigniter/user-guide/helpers/security_helper.html" target="_blank">xss_clean</a> function. 
+		A value of <dfn>TRUE</dfn>, will apply the <a href="https://www.codeigniter.com/user_guide/helpers/security_helper.html#xss_clean" target="_blank">xss_clean</a> function.
 		A value of <dfn>FALSE</dfn>, will apply no sanitation functions.
 		You can use an array to apply more than one function to sanitize your input.
 		The list of functions to sanitize the input is set by the <dfn>module_sanitize_funcs</dfn> <a href="<?=user_guide_url('installation/configuration')?>">FUEL configuration</a> value under the security settings.
@@ -30,6 +30,6 @@ CI application.</p>
 			<li><strong>template</strong> = php_to_template_syntax</li>
 			<li><strong>entities</strong> = entities</li>
 		</ul>
-	<li><strong>sanitize_files</strong> (was sanitize_images) - uses <a href="http://ellislab.com/codeigniter/user-guide/helpers/security_helper.html" target="_blank">xss_clean</a> function on images.</li>
+	<li><strong>sanitize_files</strong> (was sanitize_images) - uses <a href="https://www.codeigniter.com/user_guide/helpers/security_helper.html#xss_clean" target="_blank">xss_clean</a> function on images.</li>
 </ul>
 

--- a/fuel/modules/fuel/views/_docs/general/template-parsing.php
+++ b/fuel/modules/fuel/views/_docs/general/template-parsing.php
@@ -62,9 +62,9 @@ $config['parser_refs'] = array('config', 'load', 'session', 'uri', 'input', 'use
 	<li>{swf_path('my_swf.swf')} - Maps to the <a href="<?=user_guide_url('helpers/asset_helper#func_swf_path')?>">swf_path()</a> function. The <dfn>.swf</dfn> extension is optional.</li>
 	<li>{media_path('my_movie.mov')} - Maps to the <a href="<?=user_guide_url('helpers/asset_helper#func_media_path')?>">media_path()</a> function.</li>
 	<li>{pdf_path('my_pdf.pdf')} - Maps to the <a href="<?=user_guide_url('helpers/asset_helper#func_pdf_path')?>">pdf_path()</a> function. The <dfn>.pdf</dfn> extension is optional.</li>
-	<li>{safe_mailto('my@email.com', 'text')} - Maps to the  <a href="http://ellislab.com/codeigniter/user-guide/helpers/url_helper.html" target="_blank">safe_mailto()</a> function.</li>
-	<li>{redirect('my_redirect_page')} - Maps to the <a href="http://ellislab.com/codeigniter/user-guide/helpers/url_helper.html" target="_blank">redirect()</a> function.</li>
-	<li>{show_404} - Maps to the <a href="http://ellislab.com/codeigniter/user-guide/general/errors.html" target="_blank">show_404()</a> function.</li>
+	<li>{safe_mailto('my@email.com', 'text')} - Maps to the  <a href="https://www.codeigniter.com/user_guide/helpers/url_helper.html#safe_mailto" target="_blank">safe_mailto()</a> function.</li>
+	<li>{redirect('my_redirect_page')} - Maps to the <a href="https://www.codeigniter.com/user_guide/helpers/url_helper.html#redirect" target="_blank">redirect()</a> function.</li>
+	<li>{show_404} - Maps to the <a href="https://www.codeigniter.com/user_guide/general/errors.html#show_404" target="_blank">show_404()</a> function.</li>
 </ul>
 
 <h3>Namespaced Functions</h3>

--- a/fuel/modules/fuel/views/_docs/general/views.php
+++ b/fuel/modules/fuel/views/_docs/general/views.php
@@ -1,5 +1,5 @@
 <h1>Views</h1>
-<p>Views within FUEL work just like <a href="http://ellislab.com/codeigniter/user-guide/general/views.html" target="_blank">CodeIgniter views</a> but with some extra functionality. 
+<p>Views within FUEL work just like <a href="https://www.codeigniter.com/user_guide/general/views.html" target="_blank">CodeIgniter views</a> but with some extra functionality.
 For example, you can render a page automatically without creating a controller method by using the <a href="<?=user_guide_url('general/opt-in-controllers')?>">opt-in controller method</a>.</p>
 
 <h2>Hiding Views</h2>

--- a/fuel/modules/fuel/views/_docs/installation/db-setup.php
+++ b/fuel/modules/fuel/views/_docs/installation/db-setup.php
@@ -1,2 +1,2 @@
 <h1>Setting Up the Database</h1>
-<p>FUEL uses a MySQL database (it has not been testing on other databases). It uses the standard <a href="http://ellislab.com/codeigniter/user-guide/database/configuration.html" target="_blank">CodeIgniter database config</a>.</p>
+<p>FUEL uses a MySQL database (it has not been testing on other databases). It uses the standard <a href="https://www.codeigniter.com/user_guide/database/configuration.html" target="_blank">CodeIgniter database config</a>.</p>

--- a/fuel/modules/fuel/views/_docs/installation/troubleshooting.php
+++ b/fuel/modules/fuel/views/_docs/installation/troubleshooting.php
@@ -4,9 +4,9 @@ first want to look at the following places:</p>
 
 <h2 id="codeignter">CodeIgniter</h2>
 <ul>
-	<li><a href="http://ellislab.com/codeigniter/user-guide/installation/troubleshooting.html" target="_blank">CodeIgniter Troubleshooting page</a></li>
-	<li><a href="http://ellislab.com/codeigniter/user-guide/" target="_blank">CodeIgniter User Guide</a></li>
-	<li><a href="https://ellislab.com/forums/" target="_blank">CodeIgniter Forums</a></li>
+	<li><a href="https://www.codeigniter.com/user_guide/installation/troubleshooting.html" target="_blank">CodeIgniter Troubleshooting page</a></li>
+	<li><a href="https://www.codeigniter.com/user_guide/" target="_blank">CodeIgniter User Guide</a></li>
+	<li><a href="https://forum.codeigniter.com/" target="_blank">CodeIgniter Forums</a></li>
 </ul>
 
 <h2 id="fuel-cms">FUEL CMS</h2>

--- a/fuel/modules/fuel/views/_docs/introduction/what-is-fuel.php
+++ b/fuel/modules/fuel/views/_docs/introduction/what-is-fuel.php
@@ -4,7 +4,7 @@ creating web applications. You can create your models, views and controllers and
 only use the CMS part when and if you need it. It's a hybrid of a framework and a CMS.</p>
 
 <p>FUEL CMS evolved out of the need for having a development platform that
-was a framework first and a CMS second. <a href="http://ellislab.com/codeigniter" target="_blank">CodeIgniter</a> was chosen as the framework because it is
+was a framework first and a CMS second. <a href="https://www.codeigniter.com/" target="_blank">CodeIgniter</a> was chosen as the framework because it is
 a popular, well-documented, lightweight, PHP framework and allows you to cleanly structure your code
 using MVC principles.
 </p>

--- a/fuel/modules/fuel/views/_docs/libraries/cache.php
+++ b/fuel/modules/fuel/views/_docs/libraries/cache.php
@@ -2,4 +2,4 @@
 <p>The Cache library used by FUEL, 
 was developed by Al James
 and allows for greater control of caching files beyond CodeIgniter's 
-<a href="http://ellislab.com/codeigniter/user-guide/general/caching.html" target="_blank">Caching class</a>.</p>
+<a href="https://www.codeigniter.com/user_guide/general/caching.html" target="_blank">Caching class</a>.</p>

--- a/fuel/modules/fuel/views/_docs/libraries/my_hooks.php
+++ b/fuel/modules/fuel/views/_docs/libraries/my_hooks.php
@@ -1,3 +1,3 @@
 <h1>MY_Hooks Class</h1>
-<p>The MY_Hooks class extends the native CI <a href="http://ellislab.com/codeigniter/user-guide/general/hooks.html" target="_blank">Hooks class</a> so that we could include the module name in the configuration as well
+<p>The MY_Hooks class extends the native CI <a href="https://www.codeigniter.com/user_guide/general/hooks.html" target="_blank">Hooks class</a> so that we could include the module name in the configuration as well
 as pass additional parameter when calling the hook.</p>

--- a/fuel/modules/fuel/views/_docs/libraries/my_image_lib.php
+++ b/fuel/modules/fuel/views/_docs/libraries/my_image_lib.php
@@ -1,5 +1,5 @@
 <h1>MY_Image_lib Class</h1>
-<p>The <dfn>MY_Image_lib Class</dfn> extends <a href="http://ellislab.com/codeigniter/user-guide/libraries/image_lib.html" target="_blank">CI_Image_lib</a> result class.
+<p>The <dfn>MY_Image_lib Class</dfn> extends <a href="https://www.codeigniter.com/user_guide/libraries/image_lib.html" target="_blank">CI_Image_lib</a> result class.
 It adds a couple methods listed below:
 </p>
 

--- a/fuel/modules/fuel/views/_docs/modules.php
+++ b/fuel/modules/fuel/views/_docs/modules.php
@@ -99,5 +99,5 @@ $config['uninstall_sql'] = 'fuel_blog_uninstall.sql';
 $config['repo'] = 'git://github.com/daylightstudio/FUEL-CMS-Blog-Module.git';
 </pre>
 
-<p class="important">Note that you can use <a href="http://ellislab.com/codeigniter/user-guide/libraries/migration.html" target="_blank">CodeIgniter's migrations</a> for managing SQL versioning as an
+<p class="important">Note that you can use <a href="https://www.codeigniter.com/user_guide/libraries/migration.html" target="_blank">CodeIgniter's migrations</a> for managing SQL versioning as an
 alternative to using install_sql and uninstall_sql parameters.</p>

--- a/fuel/modules/fuel/views/_docs/modules/generate.php
+++ b/fuel/modules/fuel/views/_docs/modules/generate.php
@@ -1,7 +1,7 @@
 <h1>Generate</h1>
 <p>FUEL CMS provides a command line tool to help you auto generate starter files for your simple and advanced modules. To do so, navigate 
 to the folder (e.g. using "cd") where the main bootstrap index.php file exists. Then you can type the commands below which use the
-<a href="http://ellislab.com/codeigniter/user-guide/general/cli.html" target="_blank">CodeIgniter CLI</a> to generate files automatically.</p>
+<a href="https://www.codeigniter.com/user_guide/general/cli.html" target="_blank">CodeIgniter CLI</a> to generate files automatically.</p>
 
 <h2 id="configuration">Configuration and Templates</h2>
 <p>The default generated template files exist in the <span class="file">fuel/modules/fuel/views/_generated/{type}</span> folder where <dfn>{type}</dfn>

--- a/fuel/modules/fuel/views/_docs/modules/hooks.php
+++ b/fuel/modules/fuel/views/_docs/modules/hooks.php
@@ -1,8 +1,8 @@
 <h1>Module Hooks</h1>
-<p>FUEL has extended the <a href="http://ellislab.com/codeigniter/user-guide/general/hooks.html" target="_blank">CodeIgniter Hooks</a> system to provide 
+<p>FUEL has extended the <a href="https://www.codeigniter.com/user_guide/general/hooks.html" target="_blank">CodeIgniter Hooks</a> system to provide
 extra hooks into creating, editing, and deleting of simple module data. An additional <dfn>module</dfn> hook parameter was added to allow you to add hook files
 in your advanced module folders (e.g. <dfn>fuel/modules/my_module/hooks</dfn>). To add a hook, you modify the <dfn>fuel/application/config/hooks.php</dfn>
-just like the native <a href="http://ellislab.com/codeigniter/user-guide/general/hooks.html" target="_blank">CodeIgniter Hooks</a>.</p>
+just like the native <a href="https://www.codeigniter.com/user_guide/general/hooks.html" target="_blank">CodeIgniter Hooks</a>.</p>
 
 <p>The hooks currently available are:</p>
 <ul>

--- a/fuel/modules/fuel/views/_docs/modules/simple.php
+++ b/fuel/modules/fuel/views/_docs/modules/simple.php
@@ -46,7 +46,7 @@ on the key value specified in the config (e.g. example):</p>
 		</tr>
 		<tr>
 			<td><strong>module_name</strong></td>
-			<td>The default value is a <a href="http://ellislab.com/codeigniter/user-guide/helpers/inflector_helper.html" target="_blank">humanized</a> version of the module key (e.g. a key of example = Example)</td>
+			<td>The default value is a <a href="https://www.codeigniter.com/user_guide/helpers/inflector_helper.html" target="_blank">humanized</a> version of the module key (e.g. a key of example = Example)</td>
 			<td>None</td>
 			<td>the friendly name of the module.</td>
 		</tr>

--- a/fuel/modules/fuel/views/_docs/modules/tutorial.php
+++ b/fuel/modules/fuel/views/_docs/modules/tutorial.php
@@ -257,7 +257,7 @@ $config['modules']['articles'] = array(
     second field in your table, so in our case, we really don't need to specify this value since "title" is the second field in our table but we do so 
     for demonstration purposes.</li>
     <li><strong>sanitize_input</strong>: The <dfn>sanitize_input</dfn> parameter is used to clean input before it gets inserted into the database table.
-    The default value is <var>TRUE</var> which means it will apply the <a href="http://ellislab.com/codeigniter/user-guide/helpers/security_helper.html" target="_blank">xss_clean</a> 
+    The default value is <var>TRUE</var> which means it will apply the <a href="https://www.codeigniter.com/user_guide/helpers/security_helper.html" target="_blank">xss_clean</a>
     function. In some cases, this default value is too restrictive and will not allow you to input javascript or iframe code. So instead, you 
     can specify an array of options that are available from FUEL's <a href="<?=user_guide_url('installation/configuration')?>">module_sanitize_funcs</a> config parameter. In this case, we will use
     the <var>template</var> and <var>php</var> value that maps to FUEL's <a href="<?=user_guide_url('helpers/my_string_helper#func_php_to_template_syntax')?>">php_to_template_syntax</a> and <a href="http://php.net/manual/en/function.htmlentities.php" target="_blank">htmlentities</a> function respectively.</li>


### PR DESCRIPTION
* Updates URLs in the User Guide and several classes to point to CodeIgniter.com rather than EllisLab.
* Fixes several URLs to point straight to the CI function in question (`#function_name` at end of URL)