### PR TITLE
Force use of 'filter_var' (introduced in PHP 5.2.0) in Validator helper

### DIFF
--- a/fuel/modules/fuel/helpers/validator_helper.php
+++ b/fuel/modules/fuel/helpers/validator_helper.php
@@ -122,14 +122,7 @@ if ( ! function_exists('valid_email'))
 	 */
 	function valid_email($email)
 	{
-		if (function_exists('filter_var'))
-		{
-			return filter_var($email, FILTER_VALIDATE_EMAIL);
-		}
-		else
-		{
-			return ( ! preg_match("/^([a-z0-9\+_\-]+)(\.[a-z0-9\+_\-]+)*@([a-z0-9\-]+\.)+[a-z]{2,10}$/ix", $email)) ? FALSE : TRUE;
-		}
+        return filter_var($email, FILTER_VALIDATE_EMAIL);
 	}
 } 
 


### PR DESCRIPTION
* Fuel CMS requires [PHP 5.4 or greater](http://docs.getfuelcms.com/installation/requirements)
* filter_var along with the filters [was added in 5.2.0](http://php.net/manual/en/function.filter-var.php)

I think we can get rid of the complicated regex there and leave it up to PHP to decide whether an e-mail is valid.