### PR TITLE
Fix broken 'to_json' test in 'My_model_test'

### DIFF
--- a/fuel/modules/fuel/tests/My_model_test.php
+++ b/fuel/modules/fuel/tests/My_model_test.php
@@ -26,7 +26,7 @@ class My_model_test extends Tester_base {
 		$record = $test_custom_records_model->find_one(array('email' => 'dave@thedaylightstudio.com'));
 
 		$test = $record->to_json();
-		$expected = '{"id":"2","user_name":"dave","password":"21232f297a57a5a743894a0e4a801fc3","email":"dave@thedaylightstudio.com","first_name":"Dave","last_name":"McReynolds","bio":"Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.","role_id":"2","attributes":"","active":"yes","date_added":"2012-01-01 00:00:00","full_name":"Dave McReynolds"}';
+		$expected = '{"id":2,"user_name":"dave","password":"21232f297a57a5a743894a0e4a801fc3","email":"dave@thedaylightstudio.com","first_name":"Dave","last_name":"McReynolds","bio":"Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.","role_id":2,"attributes":"","active":"yes","date_added":"2012-01-01 00:00:00","full_name":"Dave McReynolds"}';
 		$this->run($test, $expected, 'to_json custom record object test');
 	}
 


### PR DESCRIPTION
The `to_json` method in `MY_Model` takes all the fields, collects them into an array and runs it through `json_encode`.

The "id" and "role_id" are `int`s when they're passed to the JSON encoder. This causes one of the tests to fail.

This is the only broken `My_model_test` test.