### PR TITLE
Remove unnecessary permission 'create' call

### DIFF
--- a/fuel/modules/fuel/controllers/Generate.php
+++ b/fuel/modules/fuel/controllers/Generate.php
@@ -49,9 +49,6 @@ class Generate extends Fuel_base_controller {
 
 		foreach($names as $name) $this->_advanced($name);
 
-		// create a generic permission for the advanced module
-		$this->fuel->permissions->create($name);
-
 		$vars['created'] = $this->created;
 		$vars['errors'] = $this->errors;
 		$vars['modified'] = $this->modified;


### PR DESCRIPTION
The `\Generate::advanced` method takes a `$name` argument which can be either a single advanced module name or multiple names joined with a colon.

Each name goes through an internal `\Generate::_advanced` method which sets up everything about the module, including permissions (see last line of method).

This means the last call is unnecessary. If you debug that line it always returns `FALSE` because the permission is already there!