### PR TITLE
Fix get_items_in_path method returning NULL instead of an empty array.

### DIFF
--- a/fuel/modules/fuel/libraries/Menu.php
+++ b/fuel/modules/fuel/libraries/Menu.php
@@ -1038,7 +1038,7 @@ class Menu {
 	 * @access	public
 	 * @param	string active element
 	 * @param	boolean first time iterating through?
-	 * @return	string
+	 * @return	array
 	 */
 	public function get_items_in_path($active, $first_time = TRUE){
 		static $active_items = array();
@@ -1061,7 +1061,7 @@ class Menu {
 		}
 		else
 		{
-			return;
+			return $active_items;
 		}
 		
 		if (!in_array($active, $active_items)) $active_items[] = $active;

--- a/fuel/modules/fuel/libraries/Menu.php
+++ b/fuel/modules/fuel/libraries/Menu.php
@@ -1061,7 +1061,7 @@ class Menu {
 		}
 		else
 		{
-			return $active_items;
+			return array();
 		}
 		
 		if (!in_array($active, $active_items)) $active_items[] = $active;


### PR DESCRIPTION
This causes warnings in PHP 7.2+ as the NULL is passed to 'count'. See `\Menu::_render_breadcrumb`. 