### PR TITLE
Fix wrong case in 'require_once' statement in module documentation.

### DIFF
--- a/fuel/modules/fuel/views/_docs/modules/simple.php
+++ b/fuel/modules/fuel/views/_docs/modules/simple.php
@@ -528,7 +528,7 @@ CREATE TABLE `articles` (
 <pre class="brush:php">
 &lt;?php  if (!defined('BASEPATH')) exit('No direct script access allowed');
 
-require_once(FUEL_PATH.'models/base_posts_model.php');
+require_once(FUEL_PATH.'models/Base_posts_model.php');
 
 class Articles_model extends Base_posts_model {
 


### PR DESCRIPTION
The require_once references a file with a lower-case name. This is not
allowed by CodeIgniter since version 3.0.