### PR TITLE
Fix unused variable in Fuel_advanced_module.

### DIFF
--- a/fuel/modules/fuel/libraries/Fuel_advanced_module.php
+++ b/fuel/modules/fuel/libraries/Fuel_advanced_module.php
@@ -277,8 +277,8 @@ class Fuel_advanced_module extends Fuel_base_library {
 				// removes '_model'... must have this suffix to work!!!
 				if ($remove_suffix)
 				{
-					$mod_name = substr($models[$key], 0, -6);
-					$models[$key] = substr($models[$key], 0, -6);
+					$model_name = substr($models[$key], 0, -6);
+					$models[$key] = $model_name;
 				}
 			}
 			


### PR DESCRIPTION
The same 'substr' operation is done twice in a row, yet the first call's
result is discarded. This commit makes sure it is used and 'substr' is
not needlessly called the second time.