### PR TITLE
Fix issues with HTML IDs in several documentation files

### DIFF
--- a/fuel/application/views/_docs/index.php
+++ b/fuel/application/views/_docs/index.php
@@ -39,7 +39,7 @@ At its core, FUEL is a PHP/MySQL, modular-based development platform built on to
 			<li><strong><a href="#blocks">Blocks</a></strong> - create reusable block elements (e.g. headers, footers, callouts, etc).</li>
 			<li><strong><a href="#categories">Categories</a></strong> - create categories to group records together.</li>
 			<li><strong><a href="#tags">Tags</a></strong> - create tags to associate with one or more other module records to allow for easy filtering.</li>
-			<li><strong><a href="sitevariables">Site Variables</a></strong> - create variables that can be used throughout your website (e.g. a contact email address).</li>
+			<li><strong><a href="#sitevariables">Site Variables</a></strong> - create variables that can be used throughout your website (e.g. a contact email address).</li>
 			<li><strong><a href="#users">Users</a></strong> - create users and associate permissions with them.</li>
 			<li><strong><a href="#permissions">Permissions</a></strong> - create permissions to associate with other users.</li>
 		</ul>

--- a/fuel/modules/fuel/views/_docs/general/forms.php
+++ b/fuel/modules/fuel/views/_docs/general/forms.php
@@ -206,7 +206,7 @@ $this->form_builder->register_custom_field($key, $custom_field);
 		<li><a href="#state">state</a></li>
 		<li><a href="#slug">slug</a></li>
 		<li><a href="#list_items">list_items</a></li>
-		<li><a href="#langauge">langauge</a></li>
+		<li><a href="#language">language</a></li>
 		<li><a href="#keyval">keyval</a></li>
 		<li><a href="#multi">multi</a> (overwritten for more functionality)</li>
 		<li><a href="#toggler">toggler</a></li>

--- a/fuel/modules/fuel/views/_docs/general/models.php
+++ b/fuel/modules/fuel/views/_docs/general/models.php
@@ -301,7 +301,7 @@ $record->get_content()
 $record->content
 </pre>
 
-<p>There are also additional <a href="#formattters">formatter</a> variations you can use on a record property &mdash; such as <dfn>{property}_formatted</dfn> and <dfn>{property}_stripped</dfn>.</p>
+<p>There are also additional <a href="#formatters">formatter</a> variations you can use on a record property &mdash; such as <dfn>{property}_formatted</dfn> and <dfn>{property}_stripped</dfn>.</p>
 <p>Using <dfn>{property}_formatted</dfn> will apply the <a href="https://www.codeigniter.com/user_guide/helpers/typography_helper.html" target="_blank">auto_typography</a>
 function if the property is a string value and if it is a date value will format the date by default to whatever is specified in the <span class="file">fuel/application/config/MY_config.php</span>.
 </p>

--- a/fuel/modules/fuel/views/_docs/general/navigation.php
+++ b/fuel/modules/fuel/views/_docs/general/navigation.php
@@ -107,7 +107,7 @@ You do not use the <a href="<?=user_guide_url('helpers/fuel_helper')?>" target="
 
 <h3 id="hdr_footermenu">Footer Menu</h3>
 <p>Another place you may want to add a list of menu items is at the footer of your layout. This can be done similar to both the <a href="#hdr_topmenu">Top Menu</a> and 
-the <a href="#sidemenu">Side Menu</a>:</p>
+the <a href="#hdr_sidemenu">Side Menu</a>:</p>
 
 <span class="file">application/views/_variables/global.php (example)</span>
 <pre class="brush: php">

--- a/fuel/modules/fuel/views/_docs/modules/tutorial.php
+++ b/fuel/modules/fuel/views/_docs/modules/tutorial.php
@@ -14,7 +14,7 @@ We will be using 3 data models (<dfn>Articles_model</dfn>, <dfn>Authors_model</d
   <li><a href="#setup">Download and Setup</a></li>
   <li><a href="#authors_module">The Authors Module</a></li>
   <li><a href="#articles_module">The Articles Module</a></li>
-  <li><a href="#categories_module">The FUEL Tags Module</a></li>
+  <li><a href="#fuel_tags_module">The FUEL Tags Module</a></li>
   <li><a href="#permissions">Setting Up Permissions</a></li>
   <li><a href="#polishing">A Little Polishing</a></li>
   <li><a href="#views">Bringing it All Into View</a></li>


### PR DESCRIPTION
* `fuel/application/views/_docs/index.php`: Missing hash symbol means the string "sitevariables" was not acting as an ID.
* `fuel/modules/fuel/views/_docs/general/forms.php`: Typo in "langauge" meant the link was not clickable.
* `fuel/modules/fuel/views/_docs/general/models.php`: Triple 't' in the word "formattters".
* `fuel/modules/fuel/views/_docs/general/navigation.php`: ID "sidemenu" does not exist, should be "hdr_sidemenu". If you look at the same sentence, the other ID mentioned in it is "hdr_topmenu".
*  `fuel/modules/fuel/views/_docs/modules/tutorial.php`: ID "categories_module" does not exist and does not make sense there!