### PR TITLE
Initialize function parameters array in 'Inspection' class.

### DIFF
--- a/fuel/modules/fuel/libraries/Inspection.php
+++ b/fuel/modules/fuel/libraries/Inspection.php
@@ -1330,6 +1330,7 @@ class Inspection_base {
 		if (method_exists($this->reflection, 'getParameters'))
 		{
 			$params = $this->reflection->getParameters();
+			$this->params = array();
 			foreach($params as $param)
 			{
 				$p = new Inspection_param($param);


### PR DESCRIPTION
PHP 7.2.0 displays warnings when NULL is passed to its 'count' function,
which is exactly what happens if the User Guide module tries rendering
a method with no arguments.

This commit fixes that by initializing the 'params' variable with an
empty array in the 'initialize' method.

![image](https://user-images.githubusercontent.com/3257241/46320239-5b950980-c5d5-11e8-91b3-a0930d31bece.png)