### PR TITLE
Return CSS path when 'css_path' function is called.

### DIFF
--- a/fuel/modules/fuel/libraries/Fuel_advanced_module.php
+++ b/fuel/modules/fuel/libraries/Fuel_advanced_module.php
@@ -774,7 +774,7 @@ class Fuel_advanced_module extends Fuel_base_library {
 	 */
 	public function css_path()
 	{
-		$this->web_path().'assets/'.strtolower($this->name).'.css';
+		return $this->web_path().'/assets/'.strtolower($this->name).'.css';
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
This adds a missing 'return' statement in Fuel_advanced_module. Given
the way the 'web_path' method works, an extra slash had to be added
before 'assets'.

A debug statement at the end of `\Fuel_tester::__construct` now shows:
> C:/xampp/htdocs/FUEL-CMS/tester/assets/tester.css

As a bonus, the `has_css()` method now actually does what it's supposed to, rather than always returning `FALSE` (as it used to always be given NULL)!