### PR TITLE
Add missing trailing underscore in PHP '__CLASS__' constant

### DIFF
--- a/fuel/modules/fuel/core/MY_Model.php
+++ b/fuel/modules/fuel/core/MY_Model.php
@@ -5186,7 +5186,7 @@ class Data_record {
 	 */	
 	public function is_empty()
 	{
-		return empty($this->_fields) AND get_class_vars(__CLASS_);
+		return empty($this->_fields) AND get_class_vars(__CLASS__);
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
Constant `__CLASS__` must have two trailing underscores.
See http://php.net/manual/en/language.constants.predefined.php