### PR TITLE
Add missing 'break' statement in \Inspection_comment::description

### DIFF
--- a/fuel/modules/fuel/libraries/Inspection.php
+++ b/fuel/modules/fuel/libraries/Inspection.php
@@ -1127,6 +1127,7 @@ class Inspection_comment {
 						$lines = preg_replace('#(.+[^\.|>]\s*)$#', '$1. ', trim($lines));
 						
 						$desc = $lines;
+						break;
 					case 'ucfirst':
 						$desc = ucfirst($desc);
 						break;


### PR DESCRIPTION
Looks like there is a missing `break;` statement in one in the cases in `Inspection_comment::description`. Without it, whenever "periods" is given to the method, `ucfirst` is run as well.