### PR TITLE
Fix various small PhpDoc issues related to return values

### DIFF
--- a/fuel/modules/fuel/core/MY_DB_mysql_driver.php
+++ b/fuel/modules/fuel/core/MY_DB_mysql_driver.php
@@ -147,7 +147,7 @@ class MY_DB_mysql_driver extends CI_DB_mysql_driver {
 	 * @access	public
 	 * @param	string	name of table
 	 * @param	string	field name
-	 * @return	string
+	 * @return	array
 	 */
 	public function table_info($table, $set_field_key = TRUE)
 	{

--- a/fuel/modules/fuel/core/MY_DB_mysql_result.php
+++ b/fuel/modules/fuel/core/MY_DB_mysql_result.php
@@ -39,7 +39,7 @@ class MY_DB_mysql_result extends CI_DB_mysql_result {
 	 *
 	 * @access	public
 	 * @param	string	field name to use as associative key
-	 * @return	void
+	 * @return	array
 	 */
 	public function result_assoc_array($key)
 	{
@@ -83,7 +83,7 @@ class MY_DB_mysql_result extends CI_DB_mysql_result {
 	 *
 	 * @access	public
 	 * @param	string	field name to use as associative key
-	 * @return	void
+	 * @return	array
 	 */
 	public function result_assoc($key)
 	{

--- a/fuel/modules/fuel/core/MY_DB_mysqli_driver.php
+++ b/fuel/modules/fuel/core/MY_DB_mysqli_driver.php
@@ -329,7 +329,7 @@ class MY_DB_mysqli_driver extends CI_DB_mysqli_driver {
 	 * Clears the compiled query string
 	 *
 	 * @access	public
-	 * @return	string
+	 * @return	void
 	 */
 	public function clear_query_string()
 	{

--- a/fuel/modules/fuel/core/MY_DB_mysqli_result.php
+++ b/fuel/modules/fuel/core/MY_DB_mysqli_result.php
@@ -39,7 +39,7 @@ class MY_DB_mysqli_result extends CI_DB_mysqli_result {
 	 *
 	 * @access	public
 	 * @param	string	field name to use as associative key
-	 * @return	void
+	 * @return	array
 	 */
 	public function result_assoc_array($key)
 	{
@@ -83,7 +83,7 @@ class MY_DB_mysqli_result extends CI_DB_mysqli_result {
 	 *
 	 * @access	public
 	 * @param	string	field name to use as associative key
-	 * @return	void
+	 * @return	array
 	 */
 	public function result_assoc($key)
 	{

--- a/fuel/modules/fuel/core/Router.php
+++ b/fuel/modules/fuel/core/Router.php
@@ -83,7 +83,8 @@ class Fuel_Router extends MX_Router
 		// Is there a literal match?  If so we're done
 		if (isset($this->routes[$uri]))
 		{
-			return $this->_set_request(explode('/', $this->routes[$uri]));
+			$this->_set_request(explode('/', $this->routes[$uri]));
+			return;
 		}
 		
 		// Get HTTP verb

--- a/fuel/modules/fuel/helpers/MY_array_helper.php
+++ b/fuel/modules/fuel/helpers/MY_array_helper.php
@@ -112,7 +112,7 @@ if ( ! function_exists('object_sorter'))
 	 * @param	mixed
 	 * @param	string
 	 * @param	string
-	 * @return	NULL
+	 * @return	void
 	 */
 	function object_sorter(&$data, $key, $order = 'asc')
 	{
@@ -250,7 +250,7 @@ if ( ! function_exists('csv_to_array'))
 	 * @param	string	the delimiter that separates each column
 	 * @param	int		the index for where the header row starts
 	 * @param	int		must be greater then the maximum line length. Setting to 0 is slightly slower, but works for any length
-	 * @return	array
+	 * @return	array|false
 	 */
 	function csv_to_array($filename = '', $delimiter =  ',', $header_row = 0, $length = 0)
 	{

--- a/fuel/modules/fuel/libraries/Cache.php
+++ b/fuel/modules/fuel/libraries/Cache.php
@@ -306,7 +306,7 @@ class Cache
 	 * 
 	 * 	@param	Cache ID
 	 * 	@param 	Cache group ID (optional)
-	 * 	@return void
+	 * 	@return int
 	 */
 	protected function _get_expiry($cache_id, $cache_group = NULL)
 	{
@@ -322,7 +322,7 @@ class Cache
 	 * 
 	 * 	@param	Cache ID
 	 * 	@param 	Cache group ID (optional)
-	 * 	@return void
+	 * 	@return string
 	 */
 	protected function _file($cache_id, $cache_group = NULL)
 	{

--- a/fuel/modules/fuel/libraries/Curl.php
+++ b/fuel/modules/fuel/libraries/Curl.php
@@ -657,7 +657,7 @@ class Curl {
 	 *
 	 * @access	public
 	 * @param	string	The URL to use for the CURL session
-	 * @return	void
+	 * @return	boolean
 	 */	
 	public function is_valid($url)
 	{

--- a/fuel/modules/fuel/libraries/Data_table.php
+++ b/fuel/modules/fuel/libraries/Data_table.php
@@ -899,7 +899,7 @@ class Data_table {
 	 * @access	protected
 	 * @param	array actions
 	 * @param	array columns
-	 * @return	void
+	 * @return	string
 	 */
 	protected function _render_actions($actions, $fields)
 	{

--- a/fuel/modules/fuel/libraries/Form_builder.php
+++ b/fuel/modules/fuel/libraries/Form_builder.php
@@ -1147,7 +1147,7 @@ class Form_builder {
 	 * 
 	 * @access	protected
 	 * @param	string	
-	 * @return	void
+	 * @return	string
 	 */
 	protected function _render_actions()
 	{
@@ -1214,7 +1214,7 @@ class Form_builder {
 	 * 
 	 * @access	protected
 	 * @param	string	
-	 * @return	void
+	 * @return	string
 	 */
 	protected function _close_form($str)
 	{
@@ -3502,7 +3502,7 @@ class Form_builder {
 	 * Alters all the field post values that have post_process attribute specified
 	 *
 	 * @access	public
-	 * @return	void
+	 * @return	array
 	 */
 	public function post_process_field_values($posted = array(), $set_post = TRUE)
 	{
@@ -4307,7 +4307,7 @@ class Form_builder_field {
 	 *
 	 * @access	public
 	 * @param	array
-	 * @return	void
+	 * @return	string
 	 */
 	public function render($params = array())
 	{

--- a/fuel/modules/fuel/libraries/Fuel.php
+++ b/fuel/modules/fuel/libraries/Fuel.php
@@ -170,7 +170,7 @@ class Fuel extends Fuel_advanced_module {
 	 *
 	 * @access	public
 	 * @param	string	Value of what part of the version number to return. Options are "major", "minor", or "patch" (optional)
-	 * @return	void
+	 * @return	string
 	 */	
 	public function version($part = NULL)
 	{

--- a/fuel/modules/fuel/libraries/Fuel_advanced_module.php
+++ b/fuel/modules/fuel/libraries/Fuel_advanced_module.php
@@ -906,7 +906,7 @@ class Fuel_advanced_module extends Fuel_base_library {
 	 */
 	public function clear_cache()
 	{
-		return $this->fuel->cache->clear_module($this->folder());
+		$this->fuel->cache->clear_module($this->folder());
 	}
 
 	// --------------------------------------------------------------------

--- a/fuel/modules/fuel/libraries/Fuel_base_library.php
+++ b/fuel/modules/fuel/libraries/Fuel_base_library.php
@@ -220,7 +220,7 @@ class Fuel_base_library {
 	 * Checks if the logged in user is authenticated to use this item based on specified permission
 	 *
 	 * @access	protected
-	 * @return	void
+	 * @return	boolean
 	 */	
 	protected function _has_permission()
 	{

--- a/fuel/modules/fuel/libraries/Fuel_parser.php
+++ b/fuel/modules/fuel/libraries/Fuel_parser.php
@@ -82,7 +82,6 @@ class Fuel_parser extends Fuel_Base_library {
 		}
 		$this->set_engine($this->fuel->config('parser_engine'));
 		$this->create_compile_dir();
-		return $this;
 	}
 
 	// --------------------------------------------------------------------

--- a/fuel/modules/fuel/libraries/MY_Image_lib.php
+++ b/fuel/modules/fuel/libraries/MY_Image_lib.php
@@ -46,7 +46,7 @@ class MY_Image_lib extends CI_Image_lib {
 	 *
 	 * @access	public
 	 * @param	array	an associative array of key/values
-	 * @return	array
+	 * @return	void
 	 */	
 	public function initialize($props = array())
 	{
@@ -65,7 +65,7 @@ class MY_Image_lib extends CI_Image_lib {
 	 * Resize and crop an image
 	 *
 	 * @access	public
-	 * @return	array
+	 * @return	boolean
 	 */	
 	public function resize_and_crop()
 	{
@@ -183,7 +183,7 @@ class MY_Image_lib extends CI_Image_lib {
 	 * @access	public
 	 * @param	array	an associative array of key/values
 	 * @param	boolean	indicates whether to remove empty array values from uri
-	 * @return	array
+	 * @return	boolean
 	 */	
 	public function convert($type = 'jpg', $delete_orig = FALSE)
 	{

--- a/fuel/modules/fuel/models/Base_module_model.php
+++ b/fuel/modules/fuel/models/Base_module_model.php
@@ -1416,7 +1416,7 @@ class Base_module_model extends MY_Model {
 	 *
 	 * @access	public
 	 * @param	array 	An array of data (optional)
-	 * @return	void
+	 * @return	array
 	 */	
 	public function vars($data = array())
 	{

--- a/fuel/modules/fuel/models/Fuel_pages_model.php
+++ b/fuel/modules/fuel/models/Fuel_pages_model.php
@@ -244,7 +244,7 @@ class Fuel_pages_model extends Base_module_model {
 	 *
 	 * @access	public
 	 * @param  string URI path to start from (e.g. about would find about/history, about/contact, etc)
-	 * @return	void
+	 * @return	array
 	 */	
 	function children($root)
 	{


### PR DESCRIPTION
Most changes are just return value updates in PhpDocs.

Several (for example, the one in Router.php) make it so that a void method is not returned. The void method is called, and then a simple `return;` follows, to make it slightly less confusing.