### PR TITLE
'auto' case

### DIFF
--- a/fuel/application/views/_install.php
+++ b/fuel/application/views/_install.php
@@ -165,7 +165,7 @@ function svg_icon($id, $width, $height, $viewbox = "0 0 126.962 115.395")
 								<li>In the <strong>fuel/application/config/MY_fuel.php</strong> file, change the <code>$config['admin_enabled']</code> configuration property to <code>TRUE</code>. If you do not want the CMS accessible, leave it as <strong>FALSE</strong>.</li>
 								<?php endif; ?>
 								<?php if ($this->config->item('fuel_mode', 'fuel') == 'views') : ?>
-								<li>In the <strong>fuel/application/config/MY_fuel.php</strong> file, change the <code>$config['fuel_mode']</code> configuration property to <code>AUTO</code>. This must be done only if you want to view pages created in the CMS.</li>
+								<li>In the <strong>fuel/application/config/MY_fuel.php</strong> file, change the <code>$config['fuel_mode']</code> configuration property to <code>auto</code>. This must be done only if you want to view pages created in the CMS.</li>
 								<?php endif; ?>
 								<?php if (!$this->config->item('sess_save_path')) : ?>
 								<li>In the <strong>fuel/application/config/config.php</strong> file, change the <code>$config['sess_save_path']</code> configuration property to a writable folder above the web root to save session files OR leave it set to <strong>NULL</strong> to use the default PHP setting.</li>

--- a/fuel/modules/fuel/views/_docs/general/pages-variables.php
+++ b/fuel/modules/fuel/views/_docs/general/pages-variables.php
@@ -7,7 +7,7 @@
 	<li><a href="#news"><strong>news</strong>: module page</a></li>
 </ul>
 
-<p class="important">Make sure the configuration of <kbd>fuel_mode</kbd> is set to <dfn>AUTO</dfn> in the <dfn>application/config/MY_fuel.php</dfn> file.</p>
+<p class="important">Make sure the configuration of <kbd>fuel_mode</kbd> is set to <dfn>auto</dfn> in the <dfn>application/config/MY_fuel.php</dfn> file.</p>
 
 
 <a name="static"></a>


### PR DESCRIPTION
Updates the installation script and documentation. The case of "auto" is updated to match what is in some of the PHP comments (`MY_fuel` has a comment that says "_options are cms, views, and auto_"), and what is returned by methods such as `\Fuel_pages::mode`.

Yes this is a _tiny_ change. However, I have to keep reminding myself whether the case actually matters when setting up new sites. I see "AUTO" in the installation script, go to `MY_fuel` to update it, and then notice it says "auto" there!

Best to be consistent.