### PR TITLE
Fix curly brace index issue (PHP7.4 deprecation)

### DIFF
--- a/fuel/modules/fuel/helpers/MY_string_helper.php
+++ b/fuel/modules/fuel/helpers/MY_string_helper.php
@@ -143,7 +143,7 @@ if (!function_exists('smart_ucwords'))
 		$i = 0;
 		foreach (explode(" ", $str) as $word)
 		{
-			$out .= (!in_array($word, $exceptions) OR $i == 0) ? strtoupper($word{0}) . substr($word, 1) . " " : $word . " ";
+			$out .= (!in_array($word, $exceptions) OR $i == 0) ? strtoupper($word[0]) . substr($word, 1) . " " : $word . " ";
 			$i++;
 		}
 		return rtrim($out);


### PR DESCRIPTION
PHP v7.4 does not allow arrays to be accessed with curly brace notation