### PR TITLE
Fix deprecated syntax in markdown_helper

### DIFF
--- a/fuel/modules/fuel/helpers/markdown_helper.php
+++ b/fuel/modules/fuel/helpers/markdown_helper.php
@@ -1561,7 +1561,7 @@ class Markdown_Parser {
 	#
 		switch ($token[0]) {
 			case "\\":
-				return $this->hashPart("&#". ord($token{1}). ";");
+				return $this->hashPart("&#". ord($token[1]). ";");
 			case "`":
 				# Search for end marker in remaining text.
 				if (preg_match('/^(.*?[^`])'.preg_quote($token).'(?!`)(.*)$/sm', 


### PR DESCRIPTION
Getting the following error accessing the login screen with a fresh installation.

PHP 7.4.6.


```
A PHP Error was encountered

Severity: 8192

Message: Array and string offset access syntax with curly braces is deprecated

Filename: helpers/markdown_helper.php

Line Number: 1564

Backtrace:

File: C:\xampp\htdocs\FUEL-CMS\fuel\application\third_party\MX\Modules.php
Line: 158
Function: _error_handler

File: C:\xampp\htdocs\FUEL-CMS\fuel\application\third_party\MX\Modules.php
Line: 158
Function: include_once

File: C:\xampp\htdocs\FUEL-CMS\fuel\modules\fuel\core\Loader.php
Line: 140
Function: load_file

File: C:\xampp\htdocs\FUEL-CMS\fuel\modules\fuel\models\Base_module_model.php
Line: 198
Function: helper

File: C:\xampp\htdocs\FUEL-CMS\fuel\modules\fuel\models\Fuel_users_model.php
Line: 49
Function: __construct

File: C:\xampp\htdocs\FUEL-CMS\fuel\modules\fuel\core\Loader.php
Line: 252
Function: __construct

File: C:\xampp\htdocs\FUEL-CMS\fuel\modules\fuel\core\Loader.php
Line: 455
Function: model

File: C:\xampp\htdocs\FUEL-CMS\fuel\modules\fuel\controllers\Login.php
Line: 29
Function: module_model

File: C:\xampp\htdocs\FUEL-CMS\index.php
Line: 364
Function: require_once
```