### PR TITLE
Detect `char` and `mediumtext` field types

### DIFF
--- a/fuel/modules/fuel/core/MY_Model.php
+++ b/fuel/modules/fuel/core/MY_Model.php
@@ -2348,7 +2348,7 @@ class MY_Model extends CI_Model {
 		
 		switch($switch)
 		{
-			case 'var' : case 'varchar': case 'string': case 'tinytext': case 'text':  case 'longtext':
+			case 'var': case 'char': case 'varchar': case 'string': case 'tinytext': case 'text': case 'longtext': case 'mediumtext':
 				return 'string';
 			case 'int': case 'tinyint': case 'smallint': case 'mediumint': case 'float':  case 'double':  case 'decimal':
 				return 'number';


### PR DESCRIPTION
formatters[1] like *_formatted or *_markdown weren't able to identify a `mediumtext` database field as type `string` and just skipped the method.

I couldn't find another way ($representatives or $formatters or represents in the field definition) to cast the field as type string. Jumping through the MY_Model::format() method lead me to this being the only valid way to getting the property formatted.

[1] https://docs.getfuelcms.com/general/models#formatters